### PR TITLE
fixed editor crash

### DIFF
--- a/docs/dist/App.js
+++ b/docs/dist/App.js
@@ -43,9 +43,7 @@ function App() {
         return [];
       }
     }, [pattern]),
-    onSchedule: useCallback((_events, cycle2) => {
-      logCycle(_events, cycle2);
-    }, [pattern]),
+    onSchedule: useCallback((_events, cycle2) => logCycle(_events, cycle2), [pattern]),
     ready: !!pattern
   });
   useEffect(() => {
@@ -57,8 +55,12 @@ function App() {
       } catch (err) {
         setMode("javascript");
         _pattern = parse(code);
+        if (_pattern?.constructor?.name !== "Pattern") {
+          const message = `got "${typeof _pattern}" instead of pattern`;
+          throw new Error(message + (typeof _pattern === "function" ? "did you foget to call a function?" : ""));
+        }
       }
-      setPattern(_pattern);
+      setPattern(() => _pattern);
       setError(void 0);
     } catch (err) {
       console.warn(err);

--- a/docs/dist/logo.svg.proxy.js
+++ b/docs/dist/logo.svg.proxy.js
@@ -1,1 +1,1 @@
-export default "/strudel/dist/logo.svg";
+export default "/dist/logo.svg";

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="/strudel/favicon.ico" />
-    <link rel="stylesheet" type="text/css" href="/strudel/global.css" />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="stylesheet" type="text/css" href="/global.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Strudel REPL" />
     <title>Strudel REPL</title>
@@ -11,6 +11,6 @@
   <body>
     <div id="root"></div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <script type="module" src="/strudel/dist/index.js"></script>
+    <script type="module" src="/dist/index.js"></script>
   </body>
 </html>

--- a/repl/src/App.tsx
+++ b/repl/src/App.tsx
@@ -69,7 +69,7 @@ function App() {
         _pattern = parse(code);
         if (_pattern?.constructor?.name !== 'Pattern') {
           const message = `got "${typeof _pattern}" instead of pattern`;
-          throw new Error(message + (typeof _pattern === 'function' ? 'did you foget to call a function?' : ''));
+          throw new Error(message + (typeof _pattern === 'function' ? ', did you forget to call a function?' : '.'));
         }
       }
       setPattern(() => _pattern); // need arrow function here! otherwise if user returns a function, react will think it's a state reducer

--- a/repl/src/App.tsx
+++ b/repl/src/App.tsx
@@ -53,31 +53,26 @@ function App() {
       },
       [pattern]
     ),
-    onSchedule: useCallback(
-      (_events, cycle) => {
-        // console.log('schedule', _events, cycle);
-        logCycle(_events, cycle);
-      },
-      [pattern]
-    ),
+    onSchedule: useCallback((_events, cycle) => logCycle(_events, cycle), [pattern]),
     ready: !!pattern,
   });
   // parse pattern when code changes
   useEffect(() => {
     try {
-      let _pattern;
+      let _pattern: Pattern;
       try {
         _pattern = h(code);
         setMode('pegjs'); // haskell mode does not recognize quotes, pegjs looks ok by accident..
-        // console.log('h _pattern', _pattern);
       } catch (err) {
         setMode('javascript');
         // code is not haskell like
         _pattern = parse(code);
-        // console.log('not haskell..', _pattern);
+        if (_pattern?.constructor?.name !== 'Pattern') {
+          const message = `got "${typeof _pattern}" instead of pattern`;
+          throw new Error(message + (typeof _pattern === 'function' ? 'did you foget to call a function?' : ''));
+        }
       }
-      setPattern(_pattern);
-      // cycle.query(cycle.activeCycle()); // reschedule active cycle
+      setPattern(() => _pattern); // need arrow function here! otherwise if user returns a function, react will think it's a state reducer
       setError(undefined);
     } catch (err: any) {
       console.warn(err);


### PR DESCRIPTION
fix: if the user entered an uncalled function like `pure("a5").slow`, the editor would crash. 
repl is built for "/".