### PR TITLE
Mini notation: add dot sub-cycles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4342,6 +4342,43 @@
         "node": ">=6"
       }
     },
+    "node_modules/gulp-jsdoc3": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-jsdoc3/-/gulp-jsdoc3-3.0.0.tgz",
+      "integrity": "sha512-rE2jAwCPA8XFi9g4V3Z3LPhZNjxuMTIYQVMjdqZAQpRfJITLVaUK3xfmiiNTMc7j+fT7pL8Q5yj7ZPRdwCJWNg==",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "beeper": "^2.0.0",
+        "debug": "^4.1.1",
+        "fancy-log": "^1.3.3",
+        "ink-docstrap": "^1.3.2",
+        "jsdoc": "^3.6.3",
+        "map-stream": "0.0.7",
+        "tmp": "0.1.0"
+      }
+    },
+    "node_modules/gulp-jsdoc3/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/gulp-jsdoc3/node_modules/tmp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "dependencies": {
+        "rimraf": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -6247,12 +6284,6 @@
       "engines": {
         "node": ">= 10.12.0"
       }
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
-      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
-      "peer": true
     },
     "node_modules/nopt": {
       "version": "5.0.0",
@@ -9276,19 +9307,12 @@
         "webmidi": "^3.0.15"
       }
     },
-    "packages/tonal/node_modules/webmidi": {
-      "version": "3.0.19",
-      "resolved": "https://registry.npmjs.org/webmidi/-/webmidi-3.0.19.tgz",
-      "integrity": "sha512-cCBrasUmTMa8bUN/kJxfTEJABP8wUgf1ZqTu84ix89yx94pg+uSVvIoUKv0/VqZnQXCGdCvFZy2E6euZ5LybmQ==",
+    "packages/tonal": {
+      "name": "@strudel.cycles/tonal",
+      "version": "0.0.1",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@rollup/plugin-babel": "^5.3.0",
-        "djipevents": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=8.5"
-      },
-      "optionalDependencies": {
-        "jzz": "^1.4.5"
+        "@strudel.cycles/core": "*"
       }
     },
     "packages/tone": {
@@ -14276,12 +14300,6 @@
         "tar": "^6.0.2",
         "which": "^2.0.2"
       }
-    },
-    "node-releases": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
-      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
-      "peer": true
     },
     "nopt": {
       "version": "5.0.0",

--- a/packages/mini/krill-parser.js
+++ b/packages/mini/krill-parser.js
@@ -259,7 +259,7 @@ function peg$parse(input, options) {
   var peg$f0 = function() { return parseFloat(text()); };
   var peg$f1 = function(chars) { return chars.join("") };
   var peg$f2 = function(s) { return s };
-  var peg$f3 = function(sc) { sc.arguments_.alignment = "t"; return sc;};
+  var peg$f3 = function(sc) { sc.arguments_.alignment = "t"; return sc; };
   var peg$f4 = function(underscores) { return { weight: underscores.length + 1 } };
   var peg$f5 = function(a) { return { weight: a } };
   var peg$f6 = function(a) { return { replicate: a  } };
@@ -273,13 +273,13 @@ function peg$parse(input, options) {
   var peg$f14 = function(c, cs) { if (cs.length == 0 && c instanceof Object) { return c;} else { cs.unshift(c); return new PatternStub(cs,"v");}  };
   var peg$f15 = function(s) { return s; };
   var peg$f16 = function(s) { return { name: "struct", args: { sequence:s }}};
-  var peg$f17 = function(s) { return { name: "target", args : { name:s}}};
+  var peg$f17 = function(s) { return { name: "target", args : { name:s }}};
   var peg$f18 = function(p, s, r) { return { name: "bjorklund", args :{ pulse: parseInt(p), step:parseInt(s) }}};
-  var peg$f19 = function(a) { return { name: "stretch", args :{ amount: a}}};
-  var peg$f20 = function(a) { return { name: "shift", args :{ amount: "-"+a}}};
-  var peg$f21 = function(a) { return { name: "shift", args :{ amount: a}}};
-  var peg$f22 = function(a) { return { name: "stretch", args :{ amount: "1/"+a}}};
-  var peg$f23 = function(s) { return { name: "scale", args :{ scale: s.join("")}}};
+  var peg$f19 = function(a) { return { name: "stretch", args :{ amount: a }}};
+  var peg$f20 = function(a) { return { name: "shift", args :{ amount: "-"+a }}};
+  var peg$f21 = function(a) { return { name: "shift", args :{ amount: a }}};
+  var peg$f22 = function(a) { return { name: "stretch", args :{ amount: "1/"+a }}};
+  var peg$f23 = function(s) { return { name: "scale", args :{ scale: s.join("") }}};
   var peg$f24 = function(s, v) { return v};
   var peg$f25 = function(s, ss) { ss.unshift(s); return new PatternStub(ss,"t"); };
   var peg$f26 = function(sg) {return sg};
@@ -732,6 +732,30 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsedot() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parsews();
+    if (input.charCodeAt(peg$currPos) === 46) {
+      s2 = peg$c0;
+      peg$currPos++;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e1); }
+    }
+    if (s2 !== peg$FAILED) {
+      s3 = peg$parsews();
+      s1 = [s1, s2, s3];
+      s0 = s1;
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parsequote() {
     var s0;
 
@@ -782,21 +806,12 @@ function peg$parse(input, options) {
           if (peg$silentFails === 0) { peg$fail(peg$e14); }
         }
         if (s0 === peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 46) {
-            s0 = peg$c0;
+          if (input.charCodeAt(peg$currPos) === 94) {
+            s0 = peg$c8;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e1); }
-          }
-          if (s0 === peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 94) {
-              s0 = peg$c8;
-              peg$currPos++;
-            } else {
-              s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e15); }
-            }
+            if (peg$silentFails === 0) { peg$fail(peg$e15); }
           }
         }
       }
@@ -832,7 +847,55 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesub_cycle() {
+  function peg$parsesub_cycle_dot_first() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = peg$parsedot();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsestack();
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f2(s2);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parsesub_cycle_dot_next() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parsedot();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsestack();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parsedot();
+        if (s3 === peg$FAILED) {
+          s3 = null;
+        }
+        peg$savedPos = s0;
+        s0 = peg$f2(s2);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parsesub_cycle_squareBrackets() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
@@ -871,6 +934,20 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parsesub_cycle() {
+    var s0;
+
+    s0 = peg$parsesub_cycle_squareBrackets();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parsesub_cycle_dot_next();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parsesub_cycle_dot_first();
+      }
     }
 
     return s0;

--- a/packages/mini/krill-parser.js
+++ b/packages/mini/krill-parser.js
@@ -178,11 +178,11 @@ function peg$parse(input, options) {
   var peg$c6 = "'";
   var peg$c7 = "#";
   var peg$c8 = "^";
-  var peg$c9 = "_";
-  var peg$c10 = "[";
-  var peg$c11 = "]";
-  var peg$c12 = "<";
-  var peg$c13 = ">";
+  var peg$c9 = "[";
+  var peg$c10 = "]";
+  var peg$c11 = "<";
+  var peg$c12 = ">";
+  var peg$c13 = "_";
   var peg$c14 = "@";
   var peg$c15 = "!";
   var peg$c16 = "(";
@@ -228,11 +228,11 @@ function peg$parse(input, options) {
   var peg$e13 = peg$classExpectation([["0", "9"], ["a", "z"], ["A", "Z"], "~"], false, false);
   var peg$e14 = peg$literalExpectation("#", false);
   var peg$e15 = peg$literalExpectation("^", false);
-  var peg$e16 = peg$literalExpectation("_", false);
-  var peg$e17 = peg$literalExpectation("[", false);
-  var peg$e18 = peg$literalExpectation("]", false);
-  var peg$e19 = peg$literalExpectation("<", false);
-  var peg$e20 = peg$literalExpectation(">", false);
+  var peg$e16 = peg$literalExpectation("[", false);
+  var peg$e17 = peg$literalExpectation("]", false);
+  var peg$e18 = peg$literalExpectation("<", false);
+  var peg$e19 = peg$literalExpectation(">", false);
+  var peg$e20 = peg$literalExpectation("_", false);
   var peg$e21 = peg$literalExpectation("@", false);
   var peg$e22 = peg$literalExpectation("!", false);
   var peg$e23 = peg$literalExpectation("(", false);
@@ -258,36 +258,37 @@ function peg$parse(input, options) {
 
   var peg$f0 = function() { return parseFloat(text()); };
   var peg$f1 = function(chars) { return chars.join("") };
-  var peg$f2 = function(s) { return s};
+  var peg$f2 = function(s) { return s };
   var peg$f3 = function(sc) { sc.arguments_.alignment = "t"; return sc;};
-  var peg$f4 = function(a) { return { weight: a} };
-  var peg$f5 = function(a) { return { replicate: a  } };
-  var peg$f6 = function(p, s, r) { return { operator : { type_: "bjorklund", arguments_ :{ pulse: p, step:s, rotation:r || 0 } } } };
-  var peg$f7 = function(a) { return { operator : { type_: "stretch", arguments_ :{ amount:a } } } };
-  var peg$f8 = function(a) { return { operator : { type_: "stretch", arguments_ :{ amount:"1/"+a } } } };
-  var peg$f9 = function(a) { return { operator : { type_: "fixed-step", arguments_ :{ amount:a } } } };
-  var peg$f10 = function(s, o) { return new ElementStub(s, o);};
-  var peg$f11 = function(s) { return new PatternStub(s,"h"); };
-  var peg$f12 = function(c, v) { return v};
-  var peg$f13 = function(c, cs) { if (cs.length == 0 && c instanceof Object) { return c;} else { cs.unshift(c); return new PatternStub(cs,"v");}  };
-  var peg$f14 = function(s) { return s; };
-  var peg$f15 = function(s) { return { name: "struct", args: { sequence:s }}};
-  var peg$f16 = function(s) { return { name: "target", args : { name:s}}};
-  var peg$f17 = function(p, s, r) { return { name: "bjorklund", args :{ pulse: parseInt(p), step:parseInt(s) }}};
-  var peg$f18 = function(a) { return { name: "stretch", args :{ amount: a}}};
-  var peg$f19 = function(a) { return { name: "shift", args :{ amount: "-"+a}}};
-  var peg$f20 = function(a) { return { name: "shift", args :{ amount: a}}};
-  var peg$f21 = function(a) { return { name: "stretch", args :{ amount: "1/"+a}}};
-  var peg$f22 = function(s) { return { name: "scale", args :{ scale: s.join("")}}};
-  var peg$f23 = function(s, v) { return v};
-  var peg$f24 = function(s, ss) { ss.unshift(s); return new PatternStub(ss,"t"); };
-  var peg$f25 = function(sg) {return sg};
-  var peg$f26 = function(o, soc) { return new OperatorStub(o.name,o.args,soc)};
-  var peg$f27 = function(sc) { return sc };
-  var peg$f28 = function(c) { return c };
-  var peg$f29 = function(v) { return new CommandStub("setcps", { value: v})};
-  var peg$f30 = function(v) { return new CommandStub("setcps", { value: (v/120/2)})};
-  var peg$f31 = function() { return new CommandStub("hush")};
+  var peg$f4 = function(underscores) { return { weight: underscores.length + 1 } };
+  var peg$f5 = function(a) { return { weight: a } };
+  var peg$f6 = function(a) { return { replicate: a  } };
+  var peg$f7 = function(p, s, r) { return { operator : { type_: "bjorklund", arguments_ :{ pulse: p, step:s, rotation:r || 0 } } } };
+  var peg$f8 = function(a) { return { operator : { type_: "stretch", arguments_ :{ amount:a } } } };
+  var peg$f9 = function(a) { return { operator : { type_: "stretch", arguments_ :{ amount:"1/"+a } } } };
+  var peg$f10 = function(a) { return { operator : { type_: "fixed-step", arguments_ :{ amount:a } } } };
+  var peg$f11 = function(s, o) { return new ElementStub(s, o);};
+  var peg$f12 = function(s) { return new PatternStub(s,"h"); };
+  var peg$f13 = function(c, v) { return v};
+  var peg$f14 = function(c, cs) { if (cs.length == 0 && c instanceof Object) { return c;} else { cs.unshift(c); return new PatternStub(cs,"v");}  };
+  var peg$f15 = function(s) { return s; };
+  var peg$f16 = function(s) { return { name: "struct", args: { sequence:s }}};
+  var peg$f17 = function(s) { return { name: "target", args : { name:s}}};
+  var peg$f18 = function(p, s, r) { return { name: "bjorklund", args :{ pulse: parseInt(p), step:parseInt(s) }}};
+  var peg$f19 = function(a) { return { name: "stretch", args :{ amount: a}}};
+  var peg$f20 = function(a) { return { name: "shift", args :{ amount: "-"+a}}};
+  var peg$f21 = function(a) { return { name: "shift", args :{ amount: a}}};
+  var peg$f22 = function(a) { return { name: "stretch", args :{ amount: "1/"+a}}};
+  var peg$f23 = function(s) { return { name: "scale", args :{ scale: s.join("")}}};
+  var peg$f24 = function(s, v) { return v};
+  var peg$f25 = function(s, ss) { ss.unshift(s); return new PatternStub(ss,"t"); };
+  var peg$f26 = function(sg) {return sg};
+  var peg$f27 = function(o, soc) { return new OperatorStub(o.name,o.args,soc)};
+  var peg$f28 = function(sc) { return sc };
+  var peg$f29 = function(c) { return c };
+  var peg$f30 = function(v) { return new CommandStub("setcps", { value: v})};
+  var peg$f31 = function(v) { return new CommandStub("setcps", { value: (v/120/2)})};
+  var peg$f32 = function() { return new CommandStub("hush")};
 
   var peg$currPos = 0;
   var peg$savedPos = 0;
@@ -796,15 +797,6 @@ function peg$parse(input, options) {
               s0 = peg$FAILED;
               if (peg$silentFails === 0) { peg$fail(peg$e15); }
             }
-            if (s0 === peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 95) {
-                s0 = peg$c9;
-                peg$currPos++;
-              } else {
-                s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e16); }
-              }
-            }
           }
         }
       }
@@ -846,11 +838,11 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parsews();
     if (input.charCodeAt(peg$currPos) === 91) {
-      s2 = peg$c10;
+      s2 = peg$c9;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e17); }
+      if (peg$silentFails === 0) { peg$fail(peg$e16); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parsews();
@@ -858,11 +850,11 @@ function peg$parse(input, options) {
       if (s4 !== peg$FAILED) {
         s5 = peg$parsews();
         if (input.charCodeAt(peg$currPos) === 93) {
-          s6 = peg$c11;
+          s6 = peg$c10;
           peg$currPos++;
         } else {
           s6 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e18); }
+          if (peg$silentFails === 0) { peg$fail(peg$e17); }
         }
         if (s6 !== peg$FAILED) {
           s7 = peg$parsews();
@@ -890,11 +882,11 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parsews();
     if (input.charCodeAt(peg$currPos) === 60) {
-      s2 = peg$c12;
+      s2 = peg$c11;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e19); }
+      if (peg$silentFails === 0) { peg$fail(peg$e18); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parsews();
@@ -902,11 +894,11 @@ function peg$parse(input, options) {
       if (s4 !== peg$FAILED) {
         s5 = peg$parsews();
         if (input.charCodeAt(peg$currPos) === 62) {
-          s6 = peg$c13;
+          s6 = peg$c12;
           peg$currPos++;
         } else {
           s6 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e20); }
+          if (peg$silentFails === 0) { peg$fail(peg$e19); }
         }
         if (s6 !== peg$FAILED) {
           s7 = peg$parsews();
@@ -945,22 +937,80 @@ function peg$parse(input, options) {
   function peg$parseslice_modifier() {
     var s0;
 
-    s0 = peg$parseslice_weight();
+    s0 = peg$parseslice_weight_underscore();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseslice_bjorklund();
+      s0 = peg$parseslice_weight();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseslice_slow();
+        s0 = peg$parseslice_bjorklund();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseslice_fast();
+          s0 = peg$parseslice_slow();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseslice_fixed_step();
+            s0 = peg$parseslice_fast();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseslice_replicate();
+              s0 = peg$parseslice_fixed_step();
+              if (s0 === peg$FAILED) {
+                s0 = peg$parseslice_replicate();
+              }
             }
           }
         }
       }
     }
+
+    return s0;
+  }
+
+  function peg$parseslice_weight_underscore() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parsews();
+    if (input.charCodeAt(peg$currPos) === 95) {
+      s4 = peg$c13;
+      peg$currPos++;
+    } else {
+      s4 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e20); }
+    }
+    if (s4 !== peg$FAILED) {
+      s5 = peg$parsews();
+      s3 = [s3, s4, s5];
+      s2 = s3;
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        s2 = peg$currPos;
+        s3 = peg$parsews();
+        if (input.charCodeAt(peg$currPos) === 95) {
+          s4 = peg$c13;
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e20); }
+        }
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parsews();
+          s3 = [s3, s4, s5];
+          s2 = s3;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$f4(s1);
+    }
+    s0 = s1;
 
     return s0;
   }
@@ -980,7 +1030,7 @@ function peg$parse(input, options) {
       s2 = peg$parsenumber();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f4(s2);
+        s0 = peg$f5(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1008,7 +1058,7 @@ function peg$parse(input, options) {
       s2 = peg$parsenumber();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f5(s2);
+        s0 = peg$f6(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1062,7 +1112,7 @@ function peg$parse(input, options) {
             }
             if (s13 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f6(s3, s7, s11);
+              s0 = peg$f7(s3, s7, s11);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -1102,7 +1152,7 @@ function peg$parse(input, options) {
       s2 = peg$parsenumber();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f7(s2);
+        s0 = peg$f8(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1130,7 +1180,7 @@ function peg$parse(input, options) {
       s2 = peg$parsenumber();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f8(s2);
+        s0 = peg$f9(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1158,7 +1208,7 @@ function peg$parse(input, options) {
       s2 = peg$parsenumber();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f9(s2);
+        s0 = peg$f10(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1182,7 +1232,7 @@ function peg$parse(input, options) {
         s2 = null;
       }
       peg$savedPos = s0;
-      s0 = peg$f10(s1, s2);
+      s0 = peg$f11(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1207,7 +1257,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f11(s1);
+      s1 = peg$f12(s1);
     }
     s0 = s1;
 
@@ -1227,7 +1277,7 @@ function peg$parse(input, options) {
         s5 = peg$parsesingle_cycle();
         if (s5 !== peg$FAILED) {
           peg$savedPos = s3;
-          s3 = peg$f12(s1, s5);
+          s3 = peg$f13(s1, s5);
         } else {
           peg$currPos = s3;
           s3 = peg$FAILED;
@@ -1244,7 +1294,7 @@ function peg$parse(input, options) {
           s5 = peg$parsesingle_cycle();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s3 = peg$f12(s1, s5);
+            s3 = peg$f13(s1, s5);
           } else {
             peg$currPos = s3;
             s3 = peg$FAILED;
@@ -1255,7 +1305,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f13(s1, s2);
+      s0 = peg$f14(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1276,7 +1326,7 @@ function peg$parse(input, options) {
         s4 = peg$parsequote();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f14(s3);
+          s0 = peg$f15(s3);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1338,7 +1388,7 @@ function peg$parse(input, options) {
       s3 = peg$parsesequence_or_operator();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f15(s3);
+        s0 = peg$f16(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1371,7 +1421,7 @@ function peg$parse(input, options) {
           s5 = peg$parsequote();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f16(s4);
+            s0 = peg$f17(s4);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1416,7 +1466,7 @@ function peg$parse(input, options) {
             s7 = null;
           }
           peg$savedPos = s0;
-          s0 = peg$f17(s3, s5, s7);
+          s0 = peg$f18(s3, s5, s7);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1449,7 +1499,7 @@ function peg$parse(input, options) {
       s3 = peg$parsenumber();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f18(s3);
+        s0 = peg$f19(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1478,7 +1528,7 @@ function peg$parse(input, options) {
       s3 = peg$parsenumber();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f19(s3);
+        s0 = peg$f20(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1507,7 +1557,7 @@ function peg$parse(input, options) {
       s3 = peg$parsenumber();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f20(s3);
+        s0 = peg$f21(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1536,7 +1586,7 @@ function peg$parse(input, options) {
       s3 = peg$parsenumber();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f21(s3);
+        s0 = peg$f22(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1578,7 +1628,7 @@ function peg$parse(input, options) {
           s5 = peg$parsequote();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f22(s4);
+            s0 = peg$f23(s4);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1653,11 +1703,11 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parsews();
       if (input.charCodeAt(peg$currPos) === 91) {
-        s3 = peg$c10;
+        s3 = peg$c9;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e17); }
+        if (peg$silentFails === 0) { peg$fail(peg$e16); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsews();
@@ -1670,7 +1720,7 @@ function peg$parse(input, options) {
             s9 = peg$parsesequence_or_operator();
             if (s9 !== peg$FAILED) {
               peg$savedPos = s7;
-              s7 = peg$f23(s5, s9);
+              s7 = peg$f24(s5, s9);
             } else {
               peg$currPos = s7;
               s7 = peg$FAILED;
@@ -1687,7 +1737,7 @@ function peg$parse(input, options) {
               s9 = peg$parsesequence_or_operator();
               if (s9 !== peg$FAILED) {
                 peg$savedPos = s7;
-                s7 = peg$f23(s5, s9);
+                s7 = peg$f24(s5, s9);
               } else {
                 peg$currPos = s7;
                 s7 = peg$FAILED;
@@ -1699,15 +1749,15 @@ function peg$parse(input, options) {
           }
           s7 = peg$parsews();
           if (input.charCodeAt(peg$currPos) === 93) {
-            s8 = peg$c11;
+            s8 = peg$c10;
             peg$currPos++;
           } else {
             s8 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e18); }
+            if (peg$silentFails === 0) { peg$fail(peg$e17); }
           }
           if (s8 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f24(s5, s6);
+            s0 = peg$f25(s5, s6);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1753,7 +1803,7 @@ function peg$parse(input, options) {
         s4 = peg$parsecomment();
       }
       peg$savedPos = s0;
-      s0 = peg$f25(s1);
+      s0 = peg$f26(s1);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1775,7 +1825,7 @@ function peg$parse(input, options) {
           s5 = peg$parsesequence_or_operator();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f26(s1, s5);
+            s0 = peg$f27(s1, s5);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1800,7 +1850,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesequence_or_operator();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f27(s1);
+      s1 = peg$f28(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1833,7 +1883,7 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       s3 = peg$parsews();
       peg$savedPos = s0;
-      s0 = peg$f28(s2);
+      s0 = peg$f29(s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1858,7 +1908,7 @@ function peg$parse(input, options) {
       s3 = peg$parsenumber();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f29(s3);
+        s0 = peg$f30(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1887,7 +1937,7 @@ function peg$parse(input, options) {
       s3 = peg$parsenumber();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f30(s3);
+        s0 = peg$f31(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1913,7 +1963,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f31();
+      s1 = peg$f32();
     }
     s0 = s1;
 

--- a/packages/mini/krill.pegjs
+++ b/packages/mini/krill.pegjs
@@ -81,11 +81,11 @@ quote = '"' / "'"
 // ------------------ steps and cycles ---------------------------
 
 // single step definition (e.g bd)
-step_char =  [0-9a-zA-Z~] / "-" / "#" / "." / "^" / "_"
-step = ws chars:step_char+ ws { return chars.join("") }
+step_char =  [0-9a-zA-Z~] / "-" / "#" / "." / "^" 
+step = ws chars:step_char+ ws { return chars.join("") } 
 
 // define a sub cycle e.g. [1 2, 3 [4]]
-sub_cycle = ws  "[" ws s:stack ws "]" ws { return s}
+sub_cycle = ws  "[" ws s:stack ws "]" ws { return s }
 
 // define a timeline e.g <1 3 [3 5]>. We simply defer to a stack and change the alignement
 timeline = ws "<" ws sc:single_cycle ws ">" ws
@@ -96,10 +96,13 @@ slice = step / sub_cycle  / timeline
 
 // slice modifier affects the timing/size of a slice (e.g. [a b c]@3)
 // at this point, we assume we can represent them as regular sequence operators
-slice_modifier = slice_weight / slice_bjorklund / slice_slow / slice_fast / slice_fixed_step / slice_replicate
+slice_modifier = slice_weight_underscore / slice_weight / slice_bjorklund / slice_slow / slice_fast / slice_fixed_step / slice_replicate
+
+slice_weight_underscore = underscores:(ws "_" ws?)+
+  { return { weight: underscores.length + 1 } }
 
 slice_weight =  "@" a:number
-  { return { weight: a} }
+  { return { weight: a } }
   
 slice_replicate = "!"a:number
   { return { replicate: a  } }

--- a/packages/mini/krill.pegjs
+++ b/packages/mini/krill.pegjs
@@ -76,20 +76,24 @@ DIGIT  = [0-9]
 
 ws "whitespace" = [ \n\r\t]*
 comma = ws "," ws;
+dot = ws "." ws;
 quote = '"' / "'"
 
 // ------------------ steps and cycles ---------------------------
 
 // single step definition (e.g bd)
-step_char =  [0-9a-zA-Z~] / "-" / "#" / "." / "^" 
+step_char =  [0-9a-zA-Z~] / "-" / "#" / "^" 
 step = ws chars:step_char+ ws { return chars.join("") } 
 
-// define a sub cycle e.g. [1 2, 3 [4]]
-sub_cycle = ws  "[" ws s:stack ws "]" ws { return s }
+// define a sub cycle
+sub_cycle_dot_first = dot s:stack  { return s }
+sub_cycle_dot_next = dot s:stack dot? { return s }
+sub_cycle_squareBrackets = ws  "[" ws s:stack ws "]" ws { return s }
+sub_cycle =  sub_cycle_squareBrackets / sub_cycle_dot_next / sub_cycle_dot_first
 
 // define a timeline e.g <1 3 [3 5]>. We simply defer to a stack and change the alignement
 timeline = ws "<" ws sc:single_cycle ws ">" ws
-  { sc.arguments_.alignment = "t"; return sc;}
+  { sc.arguments_.alignment = "t"; return sc; }
 
 // a slice is either a single step or a sub cycle
 slice = step / sub_cycle  / timeline
@@ -146,25 +150,25 @@ struct = "struct" ws s:sequence_or_operator
   { return { name: "struct", args: { sequence:s }}}
 
 target = "target" ws quote s:step quote
-  { return { name: "target", args : { name:s}}}
+  { return { name: "target", args : { name:s }}}
 
 bjorklund = "euclid" ws p:int ws s:int ws r:int?
   { return { name: "bjorklund", args :{ pulse: parseInt(p), step:parseInt(s) }}}
 
 slow = "slow" ws a:number
-  { return { name: "stretch", args :{ amount: a}}}
+  { return { name: "stretch", args :{ amount: a }}}
 
 rotL = "rotL" ws a:number
-  { return { name: "shift", args :{ amount: "-"+a}}}
+  { return { name: "shift", args :{ amount: "-"+a }}}
 
 rotR = "rotR" ws a:number
-  { return { name: "shift", args :{ amount: a}}}
+  { return { name: "shift", args :{ amount: a }}}
 
 fast = "fast" ws a:number
-  { return { name: "stretch", args :{ amount: "1/"+a}}}
+  { return { name: "stretch", args :{ amount: "1/"+a }}}
 
 scale = "scale" ws quote s:(step_char)+ quote
-{ return { name: "scale", args :{ scale: s.join("")}}}
+{ return { name: "scale", args :{ scale: s.join("") }}}
 
 comment = '//' p:([^\n]*)
 

--- a/packages/mini/package-lock.json
+++ b/packages/mini/package-lock.json
@@ -1,0 +1,2722 @@
+{
+  "name": "@strudel.cycles/mini",
+  "version": "0.0.4",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@strudel.cycles/mini",
+      "version": "0.0.4",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@strudel.cycles/eval": "^0.0.3",
+        "@strudel.cycles/tone": "^0.0.4",
+        "peggy": "^1.2.0"
+      }
+    },
+    "../core": {
+      "name": "@strudel.cycles/core",
+      "version": "0.0.3",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "bjork": "^0.0.1",
+        "fraction.js": "^4.2.0",
+        "ramda": "^0.28.0"
+      },
+      "devDependencies": {
+        "mocha": "^9.2.2"
+      }
+    },
+    "../core/node_modules/@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../core/node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "../core/node_modules/anymatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../core/node_modules/argparse": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "../core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../core/node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/bjork": {
+      "version": "0.0.1",
+      "license": "MIT"
+    },
+    "../core/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "../core/node_modules/braces": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../core/node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "../core/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/chokidar": {
+      "version": "3.5.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "../core/node_modules/cliui": {
+      "version": "7.0.4",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "../core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "../core/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../core/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../core/node_modules/debug": {
+      "version": "4.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "../core/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../core/node_modules/decamelize": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../core/node_modules/diff": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "../core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../core/node_modules/escalade": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../core/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../core/node_modules/fill-range": {
+      "version": "7.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/find-up": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../core/node_modules/flat": {
+      "version": "5.0.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "../core/node_modules/fraction.js": {
+      "version": "4.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/infusion"
+      }
+    },
+    "../core/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../core/node_modules/fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "../core/node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "../core/node_modules/glob": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../core/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../core/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "../core/node_modules/growl": {
+      "version": "1.10.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "../core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/he": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "../core/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "../core/node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../core/node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../core/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/is-glob": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../core/node_modules/is-number": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "../core/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../core/node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../core/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "../core/node_modules/locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../core/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../core/node_modules/minimatch": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../core/node_modules/mocha": {
+      "version": "9.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "4.2.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.1",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "workerpool": "6.2.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "../core/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../core/node_modules/nanoid": {
+      "version": "3.3.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "../core/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../core/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "../core/node_modules/p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../core/node_modules/p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../core/node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../core/node_modules/picomatch": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "../core/node_modules/ramda": {
+      "version": "0.28.0",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "../core/node_modules/randombytes": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "../core/node_modules/readdirp": {
+      "version": "3.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "../core/node_modules/require-directory": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../core/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../core/node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "../core/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../core/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../core/node_modules/supports-color": {
+      "version": "8.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "../core/node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "../core/node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../core/node_modules/workerpool": {
+      "version": "6.2.0",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "../core/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "../core/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../core/node_modules/y18n": {
+      "version": "5.0.8",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../core/node_modules/yargs": {
+      "version": "16.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../core/node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../core/node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../core/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../eval": {
+      "name": "@strudel.cycles/eval",
+      "version": "0.0.3",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@strudel.cycles/core": "^0.0.3",
+        "estraverse": "^5.3.0",
+        "shift-ast": "^6.1.0",
+        "shift-codegen": "^7.0.3",
+        "shift-parser": "^7.0.3",
+        "shift-spec": "^2018.0.2",
+        "shift-traverser": "^1.0.0"
+      }
+    },
+    "../eval/node_modules/@strudel.cycles/core": {
+      "resolved": "../core",
+      "link": true
+    },
+    "../eval/node_modules/estraverse": {
+      "version": "5.3.0",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../eval/node_modules/esutils": {
+      "version": "2.0.3",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../eval/node_modules/multimap": {
+      "version": "1.1.0",
+      "license": "MIT"
+    },
+    "../eval/node_modules/object-assign": {
+      "version": "4.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../eval/node_modules/shift-ast": {
+      "version": "6.1.0",
+      "license": "Apache-2.0"
+    },
+    "../eval/node_modules/shift-codegen": {
+      "version": "7.0.3",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2",
+        "object-assign": "^4.1.0",
+        "shift-reducer": "6.0.0"
+      }
+    },
+    "../eval/node_modules/shift-parser": {
+      "version": "7.0.3",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "multimap": "^1.0.2",
+        "shift-ast": "6.0.0",
+        "shift-reducer": "6.0.0",
+        "shift-regexp-acceptor": "2.0.3"
+      }
+    },
+    "../eval/node_modules/shift-parser/node_modules/shift-ast": {
+      "version": "6.0.0",
+      "license": "Apache-2.0"
+    },
+    "../eval/node_modules/shift-reducer": {
+      "version": "6.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "shift-ast": "6.0.0"
+      }
+    },
+    "../eval/node_modules/shift-reducer/node_modules/shift-ast": {
+      "version": "6.0.0",
+      "license": "Apache-2.0"
+    },
+    "../eval/node_modules/shift-regexp-acceptor": {
+      "version": "2.0.3",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "unicode-match-property-ecmascript": "1.0.4",
+        "unicode-match-property-value-ecmascript": "1.0.2",
+        "unicode-property-aliases-ecmascript": "1.0.4"
+      }
+    },
+    "../eval/node_modules/shift-spec": {
+      "version": "2018.0.2",
+      "license": "Apache-2.0"
+    },
+    "../eval/node_modules/shift-traverser": {
+      "version": "1.0.0",
+      "dependencies": {
+        "estraverse": "4.2.0",
+        "shift-spec": "2018.0.0"
+      }
+    },
+    "../eval/node_modules/shift-traverser/node_modules/estraverse": {
+      "version": "4.2.0",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../eval/node_modules/shift-traverser/node_modules/shift-spec": {
+      "version": "2018.0.0",
+      "license": "Apache-2.0"
+    },
+    "../eval/node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../eval/node_modules/unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../eval/node_modules/unicode-match-property-value-ecmascript": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../eval/node_modules/unicode-property-aliases-ecmascript": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../tone": {
+      "name": "@strudel.cycles/tone",
+      "version": "0.0.4",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@strudel.cycles/core": "^0.0.3",
+        "@tonejs/piano": "^0.2.1",
+        "chord-voicings": "^0.0.1",
+        "tone": "^14.7.77"
+      }
+    },
+    "../tone/node_modules/@babel/runtime": {
+      "version": "7.17.8",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "../tone/node_modules/@strudel.cycles/core": {
+      "resolved": "../core",
+      "link": true
+    },
+    "../tone/node_modules/@tonaljs/abc-notation": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/array": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/chord": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-detect": "^4.6.5",
+        "@tonaljs/chord-type": "^4.6.5",
+        "@tonaljs/collection": "^4.6.2",
+        "@tonaljs/core": "^4.6.5",
+        "@tonaljs/pcset": "^4.6.5",
+        "@tonaljs/scale-type": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/chord-detect": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-type": "^4.6.5",
+        "@tonaljs/core": "^4.6.5",
+        "@tonaljs/pcset": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/chord-type": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.6.5",
+        "@tonaljs/pcset": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/collection": {
+      "version": "4.6.2",
+      "license": "MIT"
+    },
+    "../tone/node_modules/@tonaljs/core": {
+      "version": "4.6.5",
+      "license": "MIT"
+    },
+    "../tone/node_modules/@tonaljs/duration-value": {
+      "version": "4.6.2",
+      "license": "MIT"
+    },
+    "../tone/node_modules/@tonaljs/interval": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/key": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.6.5",
+        "@tonaljs/note": "^4.6.5",
+        "@tonaljs/roman-numeral": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/midi": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/mode": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "^4.6.2",
+        "@tonaljs/core": "^4.6.5",
+        "@tonaljs/interval": "^4.6.5",
+        "@tonaljs/pcset": "^4.6.5",
+        "@tonaljs/scale-type": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/note": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.6.5",
+        "@tonaljs/midi": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/pcset": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "^4.6.2",
+        "@tonaljs/core": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/progression": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord": "^4.6.5",
+        "@tonaljs/core": "^4.6.5",
+        "@tonaljs/roman-numeral": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/range": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "^4.6.2",
+        "@tonaljs/midi": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/roman-numeral": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/scale": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-type": "^4.6.5",
+        "@tonaljs/collection": "^4.6.2",
+        "@tonaljs/core": "^4.6.5",
+        "@tonaljs/note": "^4.6.5",
+        "@tonaljs/pcset": "^4.6.5",
+        "@tonaljs/scale-type": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/scale-type": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.6.5",
+        "@tonaljs/pcset": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/@tonaljs/time-signature": {
+      "version": "4.6.2",
+      "license": "MIT"
+    },
+    "../tone/node_modules/@tonaljs/tonal": {
+      "version": "4.6.5",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/abc-notation": "^4.6.5",
+        "@tonaljs/array": "^4.6.5",
+        "@tonaljs/chord": "^4.6.5",
+        "@tonaljs/chord-type": "^4.6.5",
+        "@tonaljs/collection": "^4.6.2",
+        "@tonaljs/core": "^4.6.5",
+        "@tonaljs/duration-value": "^4.6.2",
+        "@tonaljs/interval": "^4.6.5",
+        "@tonaljs/key": "^4.6.5",
+        "@tonaljs/midi": "^4.6.5",
+        "@tonaljs/mode": "^4.6.5",
+        "@tonaljs/note": "^4.6.5",
+        "@tonaljs/pcset": "^4.6.5",
+        "@tonaljs/progression": "^4.6.5",
+        "@tonaljs/range": "^4.6.5",
+        "@tonaljs/roman-numeral": "^4.6.5",
+        "@tonaljs/scale": "^4.6.5",
+        "@tonaljs/scale-type": "^4.6.5",
+        "@tonaljs/time-signature": "^4.6.2"
+      }
+    },
+    "../tone/node_modules/@tonejs/piano": {
+      "version": "0.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      },
+      "peerDependencies": {
+        "tone": "^14.6.1",
+        "webmidi": "^2.5.1"
+      }
+    },
+    "../tone/node_modules/automation-events": {
+      "version": "4.0.14",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20.1"
+      }
+    },
+    "../tone/node_modules/automation-events/node_modules/tslib": {
+      "version": "2.3.1",
+      "license": "0BSD"
+    },
+    "../tone/node_modules/chord-voicings": {
+      "version": "0.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "@tonaljs/tonal": "^4.6.5"
+      }
+    },
+    "../tone/node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "license": "MIT"
+    },
+    "../tone/node_modules/standardized-audio-context": {
+      "version": "25.3.21",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "automation-events": "^4.0.14",
+        "tslib": "^2.3.1"
+      }
+    },
+    "../tone/node_modules/standardized-audio-context/node_modules/tslib": {
+      "version": "2.3.1",
+      "license": "0BSD"
+    },
+    "../tone/node_modules/tone": {
+      "version": "14.7.77",
+      "license": "MIT",
+      "dependencies": {
+        "standardized-audio-context": "^25.1.8",
+        "tslib": "^2.0.1"
+      }
+    },
+    "../tone/node_modules/tone/node_modules/tslib": {
+      "version": "2.3.1",
+      "license": "0BSD"
+    },
+    "../tone/node_modules/tslib": {
+      "version": "1.14.1",
+      "license": "0BSD"
+    },
+    "../tone/node_modules/webmidi": {
+      "version": "2.5.3",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">0.6.x"
+      }
+    },
+    "node_modules/@strudel.cycles/eval": {
+      "resolved": "../eval",
+      "link": true
+    },
+    "node_modules/@strudel.cycles/tone": {
+      "resolved": "../tone",
+      "link": true
+    },
+    "node_modules/peggy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/peggy/-/peggy-1.2.0.tgz",
+      "integrity": "sha512-PQ+NKpAobImfMprYQtc4Egmyi29bidRGEX0kKjCU5uuW09s0Cthwqhfy7mLkwcB4VcgacE5L/ZjruD/kOPCUUw==",
+      "bin": {
+        "peggy": "bin/peggy"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  },
+  "dependencies": {
+    "@strudel.cycles/eval": {
+      "version": "file:../eval",
+      "requires": {
+        "@strudel.cycles/core": "^0.0.3",
+        "estraverse": "^5.3.0",
+        "shift-ast": "^6.1.0",
+        "shift-codegen": "^7.0.3",
+        "shift-parser": "^7.0.3",
+        "shift-spec": "^2018.0.2",
+        "shift-traverser": "^1.0.0"
+      },
+      "dependencies": {
+        "@strudel.cycles/core": {
+          "version": "file:../core",
+          "requires": {
+            "bjork": "^0.0.1",
+            "fraction.js": "^4.2.0",
+            "mocha": "^9.2.2",
+            "ramda": "^0.28.0"
+          },
+          "dependencies": {
+            "@ungap/promise-all-settled": {
+              "version": "1.1.2",
+              "dev": true
+            },
+            "ansi-colors": {
+              "version": "4.1.1",
+              "dev": true
+            },
+            "ansi-regex": {
+              "version": "5.0.1",
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "4.3.0",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "anymatch": {
+              "version": "3.1.2",
+              "dev": true,
+              "requires": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+              }
+            },
+            "argparse": {
+              "version": "2.0.1",
+              "dev": true
+            },
+            "balanced-match": {
+              "version": "1.0.2",
+              "dev": true
+            },
+            "binary-extensions": {
+              "version": "2.2.0",
+              "dev": true
+            },
+            "bjork": {
+              "version": "0.0.1"
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "braces": {
+              "version": "3.0.2",
+              "dev": true,
+              "requires": {
+                "fill-range": "^7.0.1"
+              }
+            },
+            "browser-stdout": {
+              "version": "1.3.1",
+              "dev": true
+            },
+            "camelcase": {
+              "version": "6.3.0",
+              "dev": true
+            },
+            "chalk": {
+              "version": "4.1.2",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "7.2.0",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^4.0.0"
+                  }
+                }
+              }
+            },
+            "chokidar": {
+              "version": "3.5.3",
+              "dev": true,
+              "requires": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "fsevents": "~2.3.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+              }
+            },
+            "cliui": {
+              "version": "7.0.4",
+              "dev": true,
+              "requires": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "dev": true,
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "color-name": {
+              "version": "1.1.4",
+              "dev": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "dev": true
+            },
+            "debug": {
+              "version": "4.3.3",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              },
+              "dependencies": {
+                "ms": {
+                  "version": "2.1.2",
+                  "dev": true
+                }
+              }
+            },
+            "decamelize": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "diff": {
+              "version": "5.0.0",
+              "dev": true
+            },
+            "emoji-regex": {
+              "version": "8.0.0",
+              "dev": true
+            },
+            "escalade": {
+              "version": "3.1.1",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "fill-range": {
+              "version": "7.0.1",
+              "dev": true,
+              "requires": {
+                "to-regex-range": "^5.0.1"
+              }
+            },
+            "find-up": {
+              "version": "5.0.0",
+              "dev": true,
+              "requires": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "flat": {
+              "version": "5.0.2",
+              "dev": true
+            },
+            "fraction.js": {
+              "version": "4.2.0"
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "dev": true
+            },
+            "fsevents": {
+              "version": "2.3.2",
+              "dev": true,
+              "optional": true
+            },
+            "get-caller-file": {
+              "version": "2.0.5",
+              "dev": true
+            },
+            "glob": {
+              "version": "7.2.0",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.1.2",
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                }
+              }
+            },
+            "glob-parent": {
+              "version": "5.1.2",
+              "dev": true,
+              "requires": {
+                "is-glob": "^4.0.1"
+              }
+            },
+            "growl": {
+              "version": "1.10.5",
+              "dev": true
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "he": {
+              "version": "1.2.0",
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "dev": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "dev": true
+            },
+            "is-binary-path": {
+              "version": "2.1.0",
+              "dev": true,
+              "requires": {
+                "binary-extensions": "^2.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "2.1.1",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "3.0.0",
+              "dev": true
+            },
+            "is-glob": {
+              "version": "4.0.3",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            },
+            "is-number": {
+              "version": "7.0.0",
+              "dev": true
+            },
+            "is-plain-obj": {
+              "version": "2.1.0",
+              "dev": true
+            },
+            "is-unicode-supported": {
+              "version": "0.1.0",
+              "dev": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "dev": true
+            },
+            "js-yaml": {
+              "version": "4.1.0",
+              "dev": true,
+              "requires": {
+                "argparse": "^2.0.1"
+              }
+            },
+            "locate-path": {
+              "version": "6.0.0",
+              "dev": true,
+              "requires": {
+                "p-locate": "^5.0.0"
+              }
+            },
+            "log-symbols": {
+              "version": "4.1.0",
+              "dev": true,
+              "requires": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+              }
+            },
+            "minimatch": {
+              "version": "4.2.1",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "mocha": {
+              "version": "9.2.2",
+              "dev": true,
+              "requires": {
+                "@ungap/promise-all-settled": "1.1.2",
+                "ansi-colors": "4.1.1",
+                "browser-stdout": "1.3.1",
+                "chokidar": "3.5.3",
+                "debug": "4.3.3",
+                "diff": "5.0.0",
+                "escape-string-regexp": "4.0.0",
+                "find-up": "5.0.0",
+                "glob": "7.2.0",
+                "growl": "1.10.5",
+                "he": "1.2.0",
+                "js-yaml": "4.1.0",
+                "log-symbols": "4.1.0",
+                "minimatch": "4.2.1",
+                "ms": "2.1.3",
+                "nanoid": "3.3.1",
+                "serialize-javascript": "6.0.0",
+                "strip-json-comments": "3.1.1",
+                "supports-color": "8.1.1",
+                "which": "2.0.2",
+                "workerpool": "6.2.0",
+                "yargs": "16.2.0",
+                "yargs-parser": "20.2.4",
+                "yargs-unparser": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.1.3",
+              "dev": true
+            },
+            "nanoid": {
+              "version": "3.3.1",
+              "dev": true
+            },
+            "normalize-path": {
+              "version": "3.0.0",
+              "dev": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "dev": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "p-limit": {
+              "version": "3.1.0",
+              "dev": true,
+              "requires": {
+                "yocto-queue": "^0.1.0"
+              }
+            },
+            "p-locate": {
+              "version": "5.0.0",
+              "dev": true,
+              "requires": {
+                "p-limit": "^3.0.2"
+              }
+            },
+            "path-exists": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "dev": true
+            },
+            "picomatch": {
+              "version": "2.3.1",
+              "dev": true
+            },
+            "ramda": {
+              "version": "0.28.0"
+            },
+            "randombytes": {
+              "version": "2.1.0",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.0"
+              }
+            },
+            "readdirp": {
+              "version": "3.6.0",
+              "dev": true,
+              "requires": {
+                "picomatch": "^2.2.1"
+              }
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "dev": true
+            },
+            "safe-buffer": {
+              "version": "5.2.1",
+              "dev": true
+            },
+            "serialize-javascript": {
+              "version": "6.0.0",
+              "dev": true,
+              "requires": {
+                "randombytes": "^2.1.0"
+              }
+            },
+            "string-width": {
+              "version": "4.2.3",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            },
+            "strip-json-comments": {
+              "version": "3.1.1",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "8.1.1",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            },
+            "to-regex-range": {
+              "version": "5.0.1",
+              "dev": true,
+              "requires": {
+                "is-number": "^7.0.0"
+              }
+            },
+            "which": {
+              "version": "2.0.2",
+              "dev": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "workerpool": {
+              "version": "6.2.0",
+              "dev": true
+            },
+            "wrap-ansi": {
+              "version": "7.0.0",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "dev": true
+            },
+            "y18n": {
+              "version": "5.0.8",
+              "dev": true
+            },
+            "yargs": {
+              "version": "16.2.0",
+              "dev": true,
+              "requires": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+              }
+            },
+            "yargs-parser": {
+              "version": "20.2.4",
+              "dev": true
+            },
+            "yargs-unparser": {
+              "version": "2.0.0",
+              "dev": true,
+              "requires": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+              }
+            },
+            "yocto-queue": {
+              "version": "0.1.0",
+              "dev": true
+            }
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0"
+        },
+        "esutils": {
+          "version": "2.0.3"
+        },
+        "multimap": {
+          "version": "1.1.0"
+        },
+        "object-assign": {
+          "version": "4.1.1"
+        },
+        "shift-ast": {
+          "version": "6.1.0"
+        },
+        "shift-codegen": {
+          "version": "7.0.3",
+          "requires": {
+            "esutils": "^2.0.2",
+            "object-assign": "^4.1.0",
+            "shift-reducer": "6.0.0"
+          }
+        },
+        "shift-parser": {
+          "version": "7.0.3",
+          "requires": {
+            "multimap": "^1.0.2",
+            "shift-ast": "6.0.0",
+            "shift-reducer": "6.0.0",
+            "shift-regexp-acceptor": "2.0.3"
+          },
+          "dependencies": {
+            "shift-ast": {
+              "version": "6.0.0"
+            }
+          }
+        },
+        "shift-reducer": {
+          "version": "6.0.0",
+          "requires": {
+            "shift-ast": "6.0.0"
+          },
+          "dependencies": {
+            "shift-ast": {
+              "version": "6.0.0"
+            }
+          }
+        },
+        "shift-regexp-acceptor": {
+          "version": "2.0.3",
+          "requires": {
+            "unicode-match-property-ecmascript": "1.0.4",
+            "unicode-match-property-value-ecmascript": "1.0.2",
+            "unicode-property-aliases-ecmascript": "1.0.4"
+          }
+        },
+        "shift-spec": {
+          "version": "2018.0.2"
+        },
+        "shift-traverser": {
+          "version": "1.0.0",
+          "requires": {
+            "estraverse": "4.2.0",
+            "shift-spec": "2018.0.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "4.2.0"
+            },
+            "shift-spec": {
+              "version": "2018.0.0"
+            }
+          }
+        },
+        "unicode-canonical-property-names-ecmascript": {
+          "version": "1.0.4"
+        },
+        "unicode-match-property-ecmascript": {
+          "version": "1.0.4",
+          "requires": {
+            "unicode-canonical-property-names-ecmascript": "^1.0.4",
+            "unicode-property-aliases-ecmascript": "^1.0.4"
+          }
+        },
+        "unicode-match-property-value-ecmascript": {
+          "version": "1.0.2"
+        },
+        "unicode-property-aliases-ecmascript": {
+          "version": "1.0.4"
+        }
+      }
+    },
+    "@strudel.cycles/tone": {
+      "version": "file:../tone",
+      "requires": {
+        "@strudel.cycles/core": "^0.0.3",
+        "@tonejs/piano": "^0.2.1",
+        "chord-voicings": "^0.0.1",
+        "tone": "^14.7.77"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.17.8",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@strudel.cycles/core": {
+          "version": "file:../core",
+          "requires": {
+            "bjork": "^0.0.1",
+            "fraction.js": "^4.2.0",
+            "mocha": "^9.2.2",
+            "ramda": "^0.28.0"
+          },
+          "dependencies": {
+            "@ungap/promise-all-settled": {
+              "version": "1.1.2",
+              "dev": true
+            },
+            "ansi-colors": {
+              "version": "4.1.1",
+              "dev": true
+            },
+            "ansi-regex": {
+              "version": "5.0.1",
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "4.3.0",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "anymatch": {
+              "version": "3.1.2",
+              "dev": true,
+              "requires": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+              }
+            },
+            "argparse": {
+              "version": "2.0.1",
+              "dev": true
+            },
+            "balanced-match": {
+              "version": "1.0.2",
+              "dev": true
+            },
+            "binary-extensions": {
+              "version": "2.2.0",
+              "dev": true
+            },
+            "bjork": {
+              "version": "0.0.1"
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "braces": {
+              "version": "3.0.2",
+              "dev": true,
+              "requires": {
+                "fill-range": "^7.0.1"
+              }
+            },
+            "browser-stdout": {
+              "version": "1.3.1",
+              "dev": true
+            },
+            "camelcase": {
+              "version": "6.3.0",
+              "dev": true
+            },
+            "chalk": {
+              "version": "4.1.2",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "7.2.0",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^4.0.0"
+                  }
+                }
+              }
+            },
+            "chokidar": {
+              "version": "3.5.3",
+              "dev": true,
+              "requires": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "fsevents": "~2.3.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+              }
+            },
+            "cliui": {
+              "version": "7.0.4",
+              "dev": true,
+              "requires": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "dev": true,
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "color-name": {
+              "version": "1.1.4",
+              "dev": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "dev": true
+            },
+            "debug": {
+              "version": "4.3.3",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              },
+              "dependencies": {
+                "ms": {
+                  "version": "2.1.2",
+                  "dev": true
+                }
+              }
+            },
+            "decamelize": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "diff": {
+              "version": "5.0.0",
+              "dev": true
+            },
+            "emoji-regex": {
+              "version": "8.0.0",
+              "dev": true
+            },
+            "escalade": {
+              "version": "3.1.1",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "fill-range": {
+              "version": "7.0.1",
+              "dev": true,
+              "requires": {
+                "to-regex-range": "^5.0.1"
+              }
+            },
+            "find-up": {
+              "version": "5.0.0",
+              "dev": true,
+              "requires": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "flat": {
+              "version": "5.0.2",
+              "dev": true
+            },
+            "fraction.js": {
+              "version": "4.2.0"
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "dev": true
+            },
+            "fsevents": {
+              "version": "2.3.2",
+              "dev": true,
+              "optional": true
+            },
+            "get-caller-file": {
+              "version": "2.0.5",
+              "dev": true
+            },
+            "glob": {
+              "version": "7.2.0",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.1.2",
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                }
+              }
+            },
+            "glob-parent": {
+              "version": "5.1.2",
+              "dev": true,
+              "requires": {
+                "is-glob": "^4.0.1"
+              }
+            },
+            "growl": {
+              "version": "1.10.5",
+              "dev": true
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "he": {
+              "version": "1.2.0",
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "dev": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "dev": true
+            },
+            "is-binary-path": {
+              "version": "2.1.0",
+              "dev": true,
+              "requires": {
+                "binary-extensions": "^2.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "2.1.1",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "3.0.0",
+              "dev": true
+            },
+            "is-glob": {
+              "version": "4.0.3",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            },
+            "is-number": {
+              "version": "7.0.0",
+              "dev": true
+            },
+            "is-plain-obj": {
+              "version": "2.1.0",
+              "dev": true
+            },
+            "is-unicode-supported": {
+              "version": "0.1.0",
+              "dev": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "dev": true
+            },
+            "js-yaml": {
+              "version": "4.1.0",
+              "dev": true,
+              "requires": {
+                "argparse": "^2.0.1"
+              }
+            },
+            "locate-path": {
+              "version": "6.0.0",
+              "dev": true,
+              "requires": {
+                "p-locate": "^5.0.0"
+              }
+            },
+            "log-symbols": {
+              "version": "4.1.0",
+              "dev": true,
+              "requires": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+              }
+            },
+            "minimatch": {
+              "version": "4.2.1",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "mocha": {
+              "version": "9.2.2",
+              "dev": true,
+              "requires": {
+                "@ungap/promise-all-settled": "1.1.2",
+                "ansi-colors": "4.1.1",
+                "browser-stdout": "1.3.1",
+                "chokidar": "3.5.3",
+                "debug": "4.3.3",
+                "diff": "5.0.0",
+                "escape-string-regexp": "4.0.0",
+                "find-up": "5.0.0",
+                "glob": "7.2.0",
+                "growl": "1.10.5",
+                "he": "1.2.0",
+                "js-yaml": "4.1.0",
+                "log-symbols": "4.1.0",
+                "minimatch": "4.2.1",
+                "ms": "2.1.3",
+                "nanoid": "3.3.1",
+                "serialize-javascript": "6.0.0",
+                "strip-json-comments": "3.1.1",
+                "supports-color": "8.1.1",
+                "which": "2.0.2",
+                "workerpool": "6.2.0",
+                "yargs": "16.2.0",
+                "yargs-parser": "20.2.4",
+                "yargs-unparser": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.1.3",
+              "dev": true
+            },
+            "nanoid": {
+              "version": "3.3.1",
+              "dev": true
+            },
+            "normalize-path": {
+              "version": "3.0.0",
+              "dev": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "dev": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "p-limit": {
+              "version": "3.1.0",
+              "dev": true,
+              "requires": {
+                "yocto-queue": "^0.1.0"
+              }
+            },
+            "p-locate": {
+              "version": "5.0.0",
+              "dev": true,
+              "requires": {
+                "p-limit": "^3.0.2"
+              }
+            },
+            "path-exists": {
+              "version": "4.0.0",
+              "dev": true
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "dev": true
+            },
+            "picomatch": {
+              "version": "2.3.1",
+              "dev": true
+            },
+            "ramda": {
+              "version": "0.28.0"
+            },
+            "randombytes": {
+              "version": "2.1.0",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.0"
+              }
+            },
+            "readdirp": {
+              "version": "3.6.0",
+              "dev": true,
+              "requires": {
+                "picomatch": "^2.2.1"
+              }
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "dev": true
+            },
+            "safe-buffer": {
+              "version": "5.2.1",
+              "dev": true
+            },
+            "serialize-javascript": {
+              "version": "6.0.0",
+              "dev": true,
+              "requires": {
+                "randombytes": "^2.1.0"
+              }
+            },
+            "string-width": {
+              "version": "4.2.3",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            },
+            "strip-json-comments": {
+              "version": "3.1.1",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "8.1.1",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            },
+            "to-regex-range": {
+              "version": "5.0.1",
+              "dev": true,
+              "requires": {
+                "is-number": "^7.0.0"
+              }
+            },
+            "which": {
+              "version": "2.0.2",
+              "dev": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "workerpool": {
+              "version": "6.2.0",
+              "dev": true
+            },
+            "wrap-ansi": {
+              "version": "7.0.0",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "dev": true
+            },
+            "y18n": {
+              "version": "5.0.8",
+              "dev": true
+            },
+            "yargs": {
+              "version": "16.2.0",
+              "dev": true,
+              "requires": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+              }
+            },
+            "yargs-parser": {
+              "version": "20.2.4",
+              "dev": true
+            },
+            "yargs-unparser": {
+              "version": "2.0.0",
+              "dev": true,
+              "requires": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+              }
+            },
+            "yocto-queue": {
+              "version": "0.1.0",
+              "dev": true
+            }
+          }
+        },
+        "@tonaljs/abc-notation": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/core": "^4.6.5"
+          }
+        },
+        "@tonaljs/array": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/core": "^4.6.5"
+          }
+        },
+        "@tonaljs/chord": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/chord-detect": "^4.6.5",
+            "@tonaljs/chord-type": "^4.6.5",
+            "@tonaljs/collection": "^4.6.2",
+            "@tonaljs/core": "^4.6.5",
+            "@tonaljs/pcset": "^4.6.5",
+            "@tonaljs/scale-type": "^4.6.5"
+          }
+        },
+        "@tonaljs/chord-detect": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/chord-type": "^4.6.5",
+            "@tonaljs/core": "^4.6.5",
+            "@tonaljs/pcset": "^4.6.5"
+          }
+        },
+        "@tonaljs/chord-type": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/core": "^4.6.5",
+            "@tonaljs/pcset": "^4.6.5"
+          }
+        },
+        "@tonaljs/collection": {
+          "version": "4.6.2"
+        },
+        "@tonaljs/core": {
+          "version": "4.6.5"
+        },
+        "@tonaljs/duration-value": {
+          "version": "4.6.2"
+        },
+        "@tonaljs/interval": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/core": "^4.6.5"
+          }
+        },
+        "@tonaljs/key": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/core": "^4.6.5",
+            "@tonaljs/note": "^4.6.5",
+            "@tonaljs/roman-numeral": "^4.6.5"
+          }
+        },
+        "@tonaljs/midi": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/core": "^4.6.5"
+          }
+        },
+        "@tonaljs/mode": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/collection": "^4.6.2",
+            "@tonaljs/core": "^4.6.5",
+            "@tonaljs/interval": "^4.6.5",
+            "@tonaljs/pcset": "^4.6.5",
+            "@tonaljs/scale-type": "^4.6.5"
+          }
+        },
+        "@tonaljs/note": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/core": "^4.6.5",
+            "@tonaljs/midi": "^4.6.5"
+          }
+        },
+        "@tonaljs/pcset": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/collection": "^4.6.2",
+            "@tonaljs/core": "^4.6.5"
+          }
+        },
+        "@tonaljs/progression": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/chord": "^4.6.5",
+            "@tonaljs/core": "^4.6.5",
+            "@tonaljs/roman-numeral": "^4.6.5"
+          }
+        },
+        "@tonaljs/range": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/collection": "^4.6.2",
+            "@tonaljs/midi": "^4.6.5"
+          }
+        },
+        "@tonaljs/roman-numeral": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/core": "^4.6.5"
+          }
+        },
+        "@tonaljs/scale": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/chord-type": "^4.6.5",
+            "@tonaljs/collection": "^4.6.2",
+            "@tonaljs/core": "^4.6.5",
+            "@tonaljs/note": "^4.6.5",
+            "@tonaljs/pcset": "^4.6.5",
+            "@tonaljs/scale-type": "^4.6.5"
+          }
+        },
+        "@tonaljs/scale-type": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/core": "^4.6.5",
+            "@tonaljs/pcset": "^4.6.5"
+          }
+        },
+        "@tonaljs/time-signature": {
+          "version": "4.6.2"
+        },
+        "@tonaljs/tonal": {
+          "version": "4.6.5",
+          "requires": {
+            "@tonaljs/abc-notation": "^4.6.5",
+            "@tonaljs/array": "^4.6.5",
+            "@tonaljs/chord": "^4.6.5",
+            "@tonaljs/chord-type": "^4.6.5",
+            "@tonaljs/collection": "^4.6.2",
+            "@tonaljs/core": "^4.6.5",
+            "@tonaljs/duration-value": "^4.6.2",
+            "@tonaljs/interval": "^4.6.5",
+            "@tonaljs/key": "^4.6.5",
+            "@tonaljs/midi": "^4.6.5",
+            "@tonaljs/mode": "^4.6.5",
+            "@tonaljs/note": "^4.6.5",
+            "@tonaljs/pcset": "^4.6.5",
+            "@tonaljs/progression": "^4.6.5",
+            "@tonaljs/range": "^4.6.5",
+            "@tonaljs/roman-numeral": "^4.6.5",
+            "@tonaljs/scale": "^4.6.5",
+            "@tonaljs/scale-type": "^4.6.5",
+            "@tonaljs/time-signature": "^4.6.2"
+          }
+        },
+        "@tonejs/piano": {
+          "version": "0.2.1",
+          "requires": {
+            "tslib": "^1.11.1"
+          }
+        },
+        "automation-events": {
+          "version": "4.0.14",
+          "requires": {
+            "@babel/runtime": "^7.17.2",
+            "tslib": "^2.3.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1"
+            }
+          }
+        },
+        "chord-voicings": {
+          "version": "0.0.1",
+          "requires": {
+            "@tonaljs/tonal": "^4.6.5"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9"
+        },
+        "standardized-audio-context": {
+          "version": "25.3.21",
+          "requires": {
+            "@babel/runtime": "^7.17.2",
+            "automation-events": "^4.0.14",
+            "tslib": "^2.3.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1"
+            }
+          }
+        },
+        "tone": {
+          "version": "14.7.77",
+          "requires": {
+            "standardized-audio-context": "^25.1.8",
+            "tslib": "^2.0.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.3.1"
+            }
+          }
+        },
+        "tslib": {
+          "version": "1.14.1"
+        },
+        "webmidi": {
+          "version": "2.5.3",
+          "peer": true
+        }
+      }
+    },
+    "peggy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/peggy/-/peggy-1.2.0.tgz",
+      "integrity": "sha512-PQ+NKpAobImfMprYQtc4Egmyi29bidRGEX0kKjCU5uuW09s0Cthwqhfy7mLkwcB4VcgacE5L/ZjruD/kOPCUUw=="
+    }
+  }
+}

--- a/packages/mini/package.json
+++ b/packages/mini/package.json
@@ -5,7 +5,8 @@
   "main": "mini.mjs",
   "type": "module",
   "scripts": {
-    "test": "mocha --colors"
+    "test": "mocha --colors",
+    "build-parser": "peggy -o krill-parser.js --format es ./krill.pegjs"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,7 @@
   "homepage": "https://github.com/tidalcycles/strudel#readme",
   "dependencies": {
     "@strudel.cycles/eval": "^0.0.3",
-    "@strudel.cycles/tone": "^0.0.4"
+    "@strudel.cycles/tone": "^0.0.4",
+    "peggy": "^1.2.0"
   }
 }

--- a/packages/mini/test/mini.test.mjs
+++ b/packages/mini/test/mini.test.mjs
@@ -33,9 +33,11 @@ describe('mini', () => {
     assert.deepStrictEqual(minV('[c3 d3]*2'), ['c3', 'd3', 'c3', 'd3']);
   });
 
-  it('supports brackets', () => {
+  it('supports sub-cycle', () => {
     assert.deepStrictEqual(minS('c3 [d3 e3]'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 1']);
+    assert.deepStrictEqual(minS('c3 . d3 e3'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 1']);
     assert.deepStrictEqual(minS('c3 [d3 [e3 f3]]'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 7/8', 'f3: 7/8 - 1']);
+    assert.deepStrictEqual(minS('c3 . d3 . e3 f3'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 7/8', 'f3: 7/8 - 1']);
   });
 
   it('supports commas', () => {

--- a/packages/mini/test/mini.test.mjs
+++ b/packages/mini/test/mini.test.mjs
@@ -5,42 +5,54 @@ import '@strudel.cycles/core/euclid.mjs';
 describe('mini', () => {
   const minV = (v) => mini(v)._firstCycleValues;
   const minS = (v) => mini(v)._showFirstCycle;
+
   it('supports single elements', () => {
     assert.deepStrictEqual(minV('a'), ['a']);
   });
+
   it('supports rest', () => {
     assert.deepStrictEqual(minV('~'), []);
   });
+
   it('supports cat', () => {
     assert.deepStrictEqual(minS('a b'), ['a: 0 - 1/2', 'b: 1/2 - 1']);
     assert.deepStrictEqual(minS('a b c'), ['a: 0 - 1/3', 'b: 1/3 - 2/3', 'c: 2/3 - 1']);
   });
+
   it('supports slowcat', () => {
     assert.deepStrictEqual(minV('<a b>'), ['a']);
   });
+
   it('supports division', () => {
     assert.deepStrictEqual(minS('a/2'), ['a: 0 - 2']);
     assert.deepStrictEqual(minS('[c3 d3]/2'), ['c3: 0 - 1']);
   });
+
   it('supports multiplication', () => {
     assert.deepStrictEqual(minS('c3*2'), ['c3: 0 - 1/2', 'c3: 1/2 - 1']);
     assert.deepStrictEqual(minV('[c3 d3]*2'), ['c3', 'd3', 'c3', 'd3']);
   });
+
   it('supports brackets', () => {
     assert.deepStrictEqual(minS('c3 [d3 e3]'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 1']);
     assert.deepStrictEqual(minS('c3 [d3 [e3 f3]]'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 7/8', 'f3: 7/8 - 1']);
   });
+
   it('supports commas', () => {
     assert.deepStrictEqual(minS('c3,e3,g3'), ['c3: 0 - 1', 'e3: 0 - 1', 'g3: 0 - 1']);
     assert.deepStrictEqual(minS('[c3,e3,g3] f3'), ['c3: 0 - 1/2', 'e3: 0 - 1/2', 'g3: 0 - 1/2', 'f3: 1/2 - 1']);
   });
+
   it('supports elongation', () => {
     assert.deepStrictEqual(minS('a@3 b'), ['a: 0 - 3/4', 'b: 3/4 - 1']);
     assert.deepStrictEqual(minS('a@2 b@3'), ['a: 0 - 2/5', 'b: 2/5 - 1']);
+    assert.deepStrictEqual(minS('a _ b _ _'), ['a: 0 - 2/5', 'b: 2/5 - 1']);
   });
+
   it('supports replication', () => {
     assert.deepStrictEqual(minS('a!3 b'), ['a: 0 - 1/4', 'a: 1/4 - 1/2', 'a: 1/2 - 3/4', 'b: 3/4 - 1']);
   });
+
   it('supports euclidean rhythms', () => {
     assert.deepStrictEqual(minS('a(3, 8)'), ['a: 0 - 1/8', 'a: 3/8 - 1/2', 'a: 3/4 - 7/8']);
   });

--- a/packages/mini/test/mini.test.mjs
+++ b/packages/mini/test/mini.test.mjs
@@ -37,7 +37,9 @@ describe('mini', () => {
     assert.deepStrictEqual(minS('c3 [d3 e3]'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 1']);
     assert.deepStrictEqual(minS('c3 . d3 e3'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 1']);
     assert.deepStrictEqual(minS('c3 [d3 [e3 f3]]'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 7/8', 'f3: 7/8 - 1']);
-    assert.deepStrictEqual(minS('c3 . d3 . e3 f3'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 7/8', 'f3: 7/8 - 1']);
+    assert.deepStrictEqual(minS('c3 . d3 e3'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 1']);
+    assert.deepStrictEqual(minS('c3 d3 [e3 f3]'), ['c3: 0 - 1/3', 'd3: 1/3 - 2/3', 'e3: 2/3 - 5/6', 'f3: 5/6 - 1']);
+    assert.deepStrictEqual(minS('c3 . d3 . e3 f3'), ['c3: 0 - 1/3', 'd3: 1/3 - 2/3', 'e3: 2/3 - 5/6', 'f3: 5/6 - 1']);
   });
 
   it('supports commas', () => {

--- a/packages/mini/test/mini.test.mjs
+++ b/packages/mini/test/mini.test.mjs
@@ -47,6 +47,7 @@ describe('mini', () => {
     assert.deepStrictEqual(minS('a@3 b'), ['a: 0 - 3/4', 'b: 3/4 - 1']);
     assert.deepStrictEqual(minS('a@2 b@3'), ['a: 0 - 2/5', 'b: 2/5 - 1']);
     assert.deepStrictEqual(minS('a _ b _ _'), ['a: 0 - 2/5', 'b: 2/5 - 1']);
+    assert.deepStrictEqual(minS('[a b] _'), ['a: 0 - 1/2', 'b: 1/2 - 1']);
   });
 
   it('supports replication', () => {


### PR DESCRIPTION
This pull request add the dot sub-cycles mini notation to the related package. Equivalent to existing [ ] behaviour. Expected behaviour monitored by tests is:

```javascript
assert.deepStrictEqual(minS('c3 [d3 e3]'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 1']);
assert.deepStrictEqual(minS('c3 [d3 [e3 f3]]'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 7/8', 'f3: 7/8 - 1']);
assert.deepStrictEqual(minS('c3 . d3 e3'), ['c3: 0 - 1/2', 'd3: 1/2 - 3/4', 'e3: 3/4 - 1']);
assert.deepStrictEqual(minS('c3 d3 [e3 f3]'), ['c3: 0 - 1/3', 'd3: 1/3 - 2/3', 'e3: 2/3 - 5/6', 'f3: 5/6 - 1']);
assert.deepStrictEqual(minS('c3 . d3 . e3 f3'), ['c3: 0 - 1/3', 'd3: 1/3 - 2/3', 'e3: 2/3 - 5/6', 'f3: 5/6 - 1']);
```