### PR TITLE
add createParam + createParams

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -291,4 +291,13 @@ generic_params.forEach(([type, name, description]) => {
   Pattern.prototype[name] = _setter(controls[name]);
 });
 
+// create custom param
+controls.createParam = (name) => {
+  Pattern.prototype[name] = _setter(controls[name]);
+  return (...pats) => _name(name, ...pats);
+};
+
+controls.createParams = (...names) =>
+  names.reduce((acc, name) => Object.assign(acc, { [name]: createParam(name) }), {});
+
 export default controls;


### PR DESCRIPTION
as requested by @guillaume-leo, this PR contains the methods `createParam` + `createParams` to be able to use custom params, e.g. for osc:

```js
const dudu = createParam('dudu'); // for single params
const { dada, dodo} = createParams('dada', 'dodo'); // multiple params
```

the param can then be used either to start a pattern, or as a pattern method:

```js
dudu('xxx').dada('yyy').osc(); // {dudu:'hehe', dada: 'yyy'}, osc message ['dudu','hehe','dada','yyy']
dodo('xxx').dudu('yyy').osc(); // {dodo:'hehe', dudu: 'yyy'}, osc message ['dodo','hehe','dudu','yyy']
```

the param is also patternified by default:

```js
dudu("a [b c]") // {dudu:'a'}, {dudu:'b'}, {dudu:'c'}, 
```


