### PR TITLE
Pianoroll enhancements

### DIFF
--- a/packages/tone/draw.mjs
+++ b/packages/tone/draw.mjs
@@ -20,7 +20,7 @@ export const getDrawContext = (id = 'test-canvas') => {
   return canvas.getContext('2d');
 };
 
-Pattern.prototype.draw = function (callback, cycleSpan, lookaheadCycles = 1) {
+Pattern.prototype.draw = function (callback, { from, to, onQuery }) {
   if (window.strudelAnimation) {
     cancelAnimationFrame(window.strudelAnimation);
   }
@@ -29,19 +29,22 @@ Pattern.prototype.draw = function (callback, cycleSpan, lookaheadCycles = 1) {
     events = [];
   const animate = (time) => {
     const t = Tone.getTransport().seconds;
-    if (cycleSpan) {
-      const currentCycle = Math.floor(t / cycleSpan);
+    if (from !== undefined && to !== undefined) {
+      const currentCycle = Math.floor(t);
       if (cycle !== currentCycle) {
         cycle = currentCycle;
-        const begin = currentCycle * cycleSpan;
-        const end = (currentCycle + lookaheadCycles) * cycleSpan;
-        events = this._asNumber(true) // true = silent error
-          .query(new State(new TimeSpan(begin, end)))
-          .filter(Boolean)
-          .filter((event) => event.part.begin.equals(event.whole.begin));
+        const begin = currentCycle + from;
+        const end = currentCycle + to;
+        setTimeout(() => {
+          events = this._asNumber(true) // true = silent error
+            .query(new State(new TimeSpan(begin, end)))
+            .filter(Boolean)
+            .filter((event) => event.part.begin.equals(event.whole.begin));
+          onQuery?.(events);
+        }, 0);
       }
     }
-    callback(ctx, events, t, cycleSpan, time);
+    callback(ctx, events, t, time);
     window.strudelAnimation = requestAnimationFrame(animate);
   };
   requestAnimationFrame(animate);

--- a/packages/tone/pianoroll.mjs
+++ b/packages/tone/pianoroll.mjs
@@ -21,7 +21,7 @@ Pattern.prototype.pianoroll = function ({
   background = 'transparent',
   minMidi = 10,
   maxMidi = 90,
-  autorange = 1,
+  autorange = 0,
   timeframe: timeframeProp,
   fold = 0,
   vertical = 0,

--- a/packages/tone/pianoroll.mjs
+++ b/packages/tone/pianoroll.mjs
@@ -9,8 +9,8 @@ import { Pattern } from '@strudel.cycles/core';
 const scale = (normalized, min, max) => normalized * (max - min) + min;
 
 Pattern.prototype.pianoroll = function ({
-  from = -2,
-  to = 2,
+  cycles = 4,
+  playhead = .5,
   overscan = 1,
   inactive = '#C9E597',
   active = '#FFCA28',
@@ -26,6 +26,8 @@ Pattern.prototype.pianoroll = function ({
   const ctx = getDrawContext();
   const w = ctx.canvas.width;
   const h = ctx.canvas.height;
+  const from = -cycles * playhead;
+  const to = cycles * (1 - playhead);
 
   if (timeframeProp) {
     console.warn('timeframe is deprecated! use from/to instead');
@@ -46,7 +48,7 @@ Pattern.prototype.pianoroll = function ({
   let foldValues = [];
 
   // duration to px (on timeAxis)
-  const playhead = scale(-from / timeExtent, ...timeRange);
+  const playheadPosition = scale(-from / timeExtent, ...timeRange);
   this.draw(
     (ctx, events, t) => {
       ctx.fillStyle = background;
@@ -60,11 +62,11 @@ Pattern.prototype.pianoroll = function ({
         ctx.globalAlpha = event.context.velocity ?? 1;
         ctx.beginPath();
         if (vertical) {
-          ctx.moveTo(0, playhead);
-          ctx.lineTo(valueAxis, playhead);
+          ctx.moveTo(0, playheadPosition);
+          ctx.lineTo(valueAxis, playheadPosition);
         } else {
-          ctx.moveTo(playhead, 0);
-          ctx.lineTo(playhead, valueAxis);
+          ctx.moveTo(playheadPosition, 0);
+          ctx.lineTo(playheadPosition, valueAxis);
         }
         ctx.stroke();
         const timePx = scale((event.whole.begin - from) / timeExtent, ...timeRange);

--- a/packages/tone/pianoroll.mjs
+++ b/packages/tone/pianoroll.mjs
@@ -42,7 +42,6 @@ Pattern.prototype.pianoroll = function ({
   }
   const timeAxis = vertical ? h : w;
   const valueAxis = vertical ? w : h;
-  // scale normalized value n to max pixels, flippable
   let timeRange = vertical ? [timeAxis, 0] : [0, timeAxis]; // pixel range for time
   const timeExtent = to - from; // number of seconds that fit inside the canvas frame
   const valueRange = vertical ? [0, valueAxis] : [valueAxis, 0]; // pixel range for values
@@ -52,7 +51,6 @@ Pattern.prototype.pianoroll = function ({
   flipTime && timeRange.reverse();
   flipValues && valueRange.reverse();
 
-  // duration to px (on timeAxis)
   const playheadPosition = scale(-from / timeExtent, ...timeRange);
   this.draw(
     (ctx, events, t) => {
@@ -83,7 +81,6 @@ Pattern.prototype.pianoroll = function ({
           ...valueRange,
         );
         let margin = 0;
-        // apply some pixel adjustments
         const offset = scale(t / timeExtent, ...timeRange);
         let coords;
         if (vertical) {
@@ -93,7 +90,6 @@ Pattern.prototype.pianoroll = function ({
             barThickness - 2, // width
             durationPx - 2, // height
           ];
-          // console.log(event.value, 'coords', coords);
         } else {
           coords = [
             timePx - offset + margin + 1 - (flipTime ? durationPx : 0), // x

--- a/packages/tone/pianoroll.mjs
+++ b/packages/tone/pianoroll.mjs
@@ -14,6 +14,7 @@ Pattern.prototype.pianoroll = function ({
   overscan = 1,
   flipTime = 0,
   flipValues = 0,
+  hideNegative = false,
   inactive = '#C9E597',
   active = '#FFCA28',
   // background = '#2A3236',
@@ -58,9 +59,10 @@ Pattern.prototype.pianoroll = function ({
       ctx.fillStyle = background;
       ctx.clearRect(0, 0, w, h);
       ctx.fillRect(0, 0, w, h);
-      const inFrame = (event) => event.whole.begin >= 0 && event.whole.begin <= t + to && event.whole.end >= t + from;
+      const inFrame = (event) =>
+        (!hideNegative || event.whole.begin >= 0) && event.whole.begin <= t + to && event.whole.end >= t + from;
       events.filter(inFrame).forEach((event) => {
-        const isActive = event.whole.begin <= t && event.whole.end >= t;
+        const isActive = event.whole.begin <= t && event.whole.end > t;
         ctx.fillStyle = event.context?.color || inactive;
         ctx.strokeStyle = event.context?.color || active;
         ctx.globalAlpha = event.context.velocity ?? 1;

--- a/packages/tone/pianoroll.mjs
+++ b/packages/tone/pianoroll.mjs
@@ -7,38 +7,84 @@ This program is free software: you can redistribute it and/or modify it under th
 import { Pattern } from '@strudel.cycles/core';
 
 Pattern.prototype.pianoroll = function ({
-  timeframe = 10,
+  from = -2,
+  to = 2,
+  overscan = 1,
   inactive = '#C9E597',
   active = '#FFCA28',
-  background = '#2A3236',
-  maxMidi = 90,
-  minMidi = 0,
+  // background = '#2A3236',
+  background = 'transparent',
+  maxMidi,
+  minMidi,
+  timeframe: timeFrameProp,
 } = {}) {
-  const w = window.innerWidth;
-  const h = window.innerHeight;
-  const midiRange = maxMidi - minMidi + 1;
-  const height = h / midiRange;
+  if (timeFrameProp) {
+    console.warn('timeframe is deprecated! use from/to instead');
+    from = 0;
+    to = timeFrameProp;
+  }
+  const ctx = getDrawContext();
+  const w = ctx.canvas.width;
+  const h = ctx.canvas.height;
+  let midiRange, height;
+  const autorange = minMidi === undefined || maxMidi === undefined;
+  if (autorange && (minMidi !== undefined || maxMidi !== undefined)) {
+    console.warn('pianoroll: minMidi and maxMidi must both be set to have an effect!');
+  }
+  if (!autorange) {
+    midiRange = maxMidi - minMidi + 1;
+    height = h / midiRange;
+  }
+  const timeframe = to - from;
+  const t2x = (t) => Math.round(((t - from) / timeframe) * w);
+  const playheadX = t2x(0);
   this.draw(
     (ctx, events, t) => {
       ctx.fillStyle = background;
       ctx.clearRect(0, 0, w, h);
       ctx.fillRect(0, 0, w, h);
-      events.forEach((event) => {
+      const inFrame = (event) => event.whole.begin >= 0 && event.whole.begin <= t + to && event.whole.end >= t + from;
+      events.filter(inFrame).forEach((event) => {
         const isActive = event.whole.begin <= t && event.whole.end >= t;
         ctx.fillStyle = event.context?.color || inactive;
         ctx.strokeStyle = event.context?.color || active;
         ctx.globalAlpha = event.context.velocity ?? 1;
-        const x = Math.round((event.whole.begin / timeframe) * w);
+        ctx.beginPath();
+        ctx.moveTo(playheadX, 0);
+        ctx.lineTo(playheadX, h);
+        ctx.stroke();
+        const x = t2x(event.whole.begin);
         const width = Math.round(((event.whole.end - event.whole.begin) / timeframe) * w);
-        const y = Math.round(h - ((Number(event.value) - minMidi) / midiRange) * h);
+        const y = Math.round(h - ((Number(event.value) - minMidi + 1) / midiRange) * h);
         const offset = (t / timeframe) * w;
         const margin = 0;
         const coords = [x - offset + margin + 1, y + 1, width - 2, height - 2];
         isActive ? ctx.strokeRect(...coords) : ctx.fillRect(...coords);
       });
     },
-    timeframe,
-    2, // lookaheadCycles
+    {
+      from: from - overscan,
+      to: to + overscan,
+      onQuery: (events) => {
+        if (autorange) {
+          const getValue = (e) => Number(e.value);
+          const { min, max } = events.reduce(
+            ({ min, max }, e) => {
+              const v = getValue(e);
+              return {
+                min: v < min ? v : min,
+                max: v > max ? v : max,
+              };
+            },
+            { min: Infinity, max: -Infinity },
+          );
+          minMidi = min;
+          maxMidi = max;
+          midiRange = maxMidi - minMidi + 1;
+          height = h / midiRange;
+        }
+      },
+    },
   );
   return this;
 };


### PR DESCRIPTION
I added the following options to `.pianoroll`:

```js
{
cycles = 4, // number of cycles to show
playhead = 0.5, // position of playhead, 0.5 = center
vertical = 0, // if 1, time will be on the y axis
autorange = 0, // if 1, the range of values will be deduced from the active cycles (instead of minMidi / maxMidi)
fold = 0, // if 1,  there will be no gaps between values (like ableton fold), autorange will be ignored
overscan = 1, // how many extra cycles will be queried outside the viewport, can be used to get a more stable autorange without needing to set cycles higher
flipTime = 0, // if 1, time will flow in the opposite direction
flipValues = 0, // if 1, value range will be flipped
hideNegative = 0, // if 1, haps with negative events will be hidden at start
timeframe, // now deprecated (but still works)
}
```
