### PR TITLE
add onTrigger helper

### DIFF
--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -1049,6 +1049,9 @@ export class Pattern {
       .unit('c')
       .slow(factor);
   }
+  onTrigger(onTrigger) {
+    return this._withHap((hap) => hap.setContext({ ...hap.context, onTrigger }));
+  }
 }
 
 // TODO - adopt value.mjs fully..


### PR DESCRIPTION
this helper essentially does what all the custom outputs do. It can be used to code web audio dsp in user land:

```js
freq(
  stack(
    "55 [110,165] 110 [220,275]".mul("<1 <3/4 2/3>>").struct("x(3,8)"),
    "440(5,8)".legato(.2).mul("<1 3/4 2 2/3>")
  ).superimpose(x=>x.mul(1.005))
).s("sawtooth square")
  .onTrigger((t,hap,ct)=>{
  const { freq, s } = hap.value;
  const audioContext = getAudioContext();
  t = audioContext.currentTime + t - ct;
  const o = audioContext.createOscillator();
  const master = audioContext.createGain();
  master.gain.value = 0.1;
  master.connect(audioContext.destination);
  o.type = s || 'triangle';
  o.frequency.value = Number(freq);
  o.connect(master);
  o.start(t);
  o.stop(t + hap.duration);
})
```

the above code implements an oscillator that can be patterned with `freq` and `s`! 