### PR TITLE
add webdirt drum samples to prebake for general availability

### DIFF
--- a/repl/package.json
+++ b/repl/package.json
@@ -7,7 +7,7 @@
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "mocha ./src/test --colors",
+    "test": "NODE_OPTIONS='--experimental-fetch' mocha ./src/test --colors",
     "snapshot": "cd ./src/ && rm -f ./tunes.snapshot.mjs && node ./shoot.mjs > ./tunes.snapshot.mjs",
     "add-license": "cat etc/agpl-header.txt ../docs/static/js/*LICENSE.txt > /tmp/strudel-license.txt && cp /tmp/strudel-license.txt ../docs/static/js/*LICENSE.txt",
     "predeploy": "npm run build",

--- a/repl/src/prebake.mjs
+++ b/repl/src/prebake.mjs
@@ -1,5 +1,6 @@
 import { Pattern, toMidi } from '@strudel.cycles/core';
 import { samples } from '@strudel.cycles/webaudio';
+import EmuSP12 from '../public/EmuSP12.json';
 
 export function prebake() {
   samples(
@@ -41,6 +42,7 @@ export function prebake() {
     // License: CC-by http://creativecommons.org/licenses/by/3.0/ Author: Alexander Holm
     './piano/',
   );
+  samples(EmuSP12, './EmuSP12/');
 }
 
 const maxPan = toMidi('C8');

--- a/repl/src/prebake.mjs
+++ b/repl/src/prebake.mjs
@@ -1,6 +1,6 @@
 import { Pattern, toMidi } from '@strudel.cycles/core';
 import { samples } from '@strudel.cycles/webaudio';
-import EmuSP12 from '../public/EmuSP12.json';
+import EmuSP12 from '../public/EmuSP12.json' assert {type: "json"};
 
 export function prebake() {
   samples(

--- a/repl/src/prebake.mjs
+++ b/repl/src/prebake.mjs
@@ -1,6 +1,5 @@
 import { Pattern, toMidi } from '@strudel.cycles/core';
 import { samples } from '@strudel.cycles/webaudio';
-import EmuSP12 from '../public/EmuSP12.json' assert {type: "json"};
 
 export function prebake() {
   samples(
@@ -42,7 +41,9 @@ export function prebake() {
     // License: CC-by http://creativecommons.org/licenses/by/3.0/ Author: Alexander Holm
     './piano/',
   );
-  samples(EmuSP12, './EmuSP12/');
+  fetch('EmuSP12.json')
+    .then(res => res.json())
+    .then(json => samples(json, './EmuSP12/'));
 }
 
 const maxPan = toMidi('C8');


### PR DESCRIPTION
This loads all default webdirt samples via prebake, so you can play a few drum samples with `out` as well as `webdirt`. This is mostly to make Strudel more beginner-friendly, but also so you can easily apply webaudio methods like `velocity` that webdirt doesn't support yet.