### PR TITLE
bpm and flatcat functions

### DIFF
--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -10,7 +10,7 @@ import Hap from './hap.mjs';
 import State from './state.mjs';
 import { unionWithObj } from './value.mjs';
 
-import { isNote, toMidi, compose, removeUndefineds, flatten, id, listRange, curry, mod } from './util.mjs';
+import { isNote, toMidi, compose, removeUndefineds, flatten, id, listRange, curry, mod, flattenDeep } from './util.mjs';
 import drawLine from './drawLine.mjs';
 
 /** @class Class representing a pattern. */
@@ -795,6 +795,11 @@ export class Pattern {
     return this._fast(cpm / 60);
   }
 
+  // bpm = beats per minute (assuming a 4/4 time signature)
+  _bpm(bpm) {
+    return this._slow(240 / bpm );
+  }
+
   _early(offset) {
     // Equivalent of Tidal's <~ operator
     offset = Fraction(offset);
@@ -971,6 +976,10 @@ export class Pattern {
 
   slowcat(...pats) {
     return slowcat(this, ...pats);
+  }
+
+  flatcat(...pats) {
+    return flatcat(this, ...pats);
   }
 
   superimpose(...funcs) {
@@ -1159,6 +1168,7 @@ function _composeOp(a, b, func) {
 // methods of Pattern that get callable factories
 Pattern.prototype.patternified = [
   'apply',
+  'bpm',
   'chop',
   'color',
   'cpm',
@@ -1182,6 +1192,7 @@ Pattern.prototype.factories = {
   slowcat,
   fastcat,
   cat,
+  flatcat,
   timeCat,
   sequence,
   seq,
@@ -1304,6 +1315,18 @@ export function slowcatPrime(...pats) {
  */
 export function fastcat(...pats) {
   return slowcat(...pats)._fast(pats.length);
+}
+
+/** Concatenation: as with {@link slowcat}, but deep flattens any arrays before concatenation
+ *
+ * @param {...any} items - The items to concatenate
+ * @return {Pattern}
+ * @example
+ * flatcat(e5, b4, [d5, c5])
+ * // cat(e5, b4, d5, c5)
+ */
+ export function flatcat(...pats) {
+   return slowcat(...[].concat(flattenDeep(pats)))
 }
 
 /** See {@link slowcat} */

--- a/packages/core/test/pattern.test.mjs
+++ b/packages/core/test/pattern.test.mjs
@@ -18,6 +18,7 @@ import {
   fastcat,
   slowcat,
   cat,
+  flatcat,
   sequence,
   polymeter,
   polymeterSteps,
@@ -611,6 +612,14 @@ describe('Pattern', function () {
       assert.deepStrictEqual(
         sequence('a', ['a', 'a']).firstCycle(),
         timeCat([1, 'a'], [0.5, 'a'], [0.5, 'a']).firstCycle(),
+      );
+    });
+  });
+  describe('flatcat()', function () {
+    it('Can concatenate patterns of flattened arrays', function () {
+      assert.deepStrictEqual(
+        cat(...[...[sequence(1, 2), sequence(3, 4)], sequence(5, 6)], 7).firstCycle(),
+        flatcat([[sequence(1, 2),sequence(3, 4)], sequence(5, 6)], 7).firstCycle(),
       );
     });
   });

--- a/packages/core/util.mjs
+++ b/packages/core/util.mjs
@@ -81,6 +81,8 @@ export const removeUndefineds = (xs) => xs.filter((x) => x != undefined);
 
 export const flatten = (arr) => [].concat(...arr);
 
+export const flattenDeep = (arr) => Array.isArray(arr) ? arr.reduce( (a, b) => a.concat(flattenDeep(b)) , []) : [arr];
+
 export const id = (a) => a;
 export const constant = (a, b) => a;
 

--- a/tutorial/tutorial.mdx
+++ b/tutorial/tutorial.mdx
@@ -275,6 +275,15 @@ how to use?
 
 <MiniRepl tune={`polymeter(3, e3, g3, b3)`} /> -->
 
+### flatcat(...values)
+
+Like **cat**, but any arrays are fully flattened before concatenation. 
+This is particularly useful when concatenating nested patterns of mixed or unknown type. 
+
+<MiniRepl tune={
+`flatcat([[seq(g5, f5),seq(e5, d5)], seq(c5, g4)], c5)`
+} />
+
 ### polyrhythm(...[...values])
 
 Plays the given items at the same time, within the same length:
@@ -714,6 +723,8 @@ The following functions will return a pattern. We will see later what that means
 {{ 'stack' | jsdoc }}
 
 {{ 'timeCat' | jsdoc }}
+
+{{ 'flatcat' | jsdoc }}
 
 {{ 'polyrhythm' | jsdoc }}
 


### PR DESCRIPTION
I've added two functions that are particularly useful for beginners:

* `bpm` allows to set the tempo in BPM instead of CPM. The underlying idea is that a standard cycle has 4 elements or beats (corresponding to a 4/4 time signature).
* `flatcat` is like `cat` but allows to concatenate patterns without worrying whether the items are arrays or not. It applies flattenDeep to all items before concatenating. I use it to lay out a sequence of bars in a more familiar song structure fashion. I could certainly use `cat` with the `...` spread operator, but then I would always need to know which item is an array and which is not (or test for it, which just convolutes the code).

```
var intro     = ["~ x x x", "~ x ~ x"]
var verse   = ["x ~ ~ ~", "x ~ ~ ~"]
var chorus = [intro[0],"x x x x"]
var bridge  = "x ~ x ~"
s("hh").n(1).struct( flatcat(intro, verse, chorus, bridge, verse, chorus, "x ~ ~ x") ).bpm(120).webdirt()
// the same with cat:
//s("hh").n(1).struct( cat(...intro, ...verse, ...chorus, bridge, ...verse, ...chorus, "x ~ ~ x") ).bpm(120).webdirt()
```