### PR TITLE
Amend shapeshifter to allow use of dynamic import

### DIFF
--- a/packages/eval/test/shapeshifter.test.mjs
+++ b/packages/eval/test/shapeshifter.test.mjs
@@ -11,4 +11,10 @@ describe('shapeshifter', () => {
   it('Should shift simple double quote string', () => {
     assert.equal(shapeshifter('"c3"'), '(async()=>{return mini("c3").withMiniLocation([1,0,15],[1,4,19])})()');
   });
+  it('Should handle dynamic imports', () => {
+    assert.equal(
+      shapeshifter('const { default: foo } = await import(\'https://bar.com/foo.js\');"c3"'),
+      '(async()=>{const{default:foo}=await import("https://bar.com/foo.js");return mini("c3").withMiniLocation([1,64,79],[1,68,83])})()',
+    );
+  });
 });


### PR DESCRIPTION
Whilst implementing the standard import syntax (`import foo from "./bar"`) is problematic due to the statically analyzed nature of these imports, the [dynamic import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) syntax works fine in this context. Unfortunately the shift parser does not support dynamic import and actually throws an error when it sees the keyword, so I have implemented a mildly hacky solution which swaps it out before parsing, then swaps it back in again afterwards.

You can see it working by running this code in the REPL:

```
const { default: confetti } = await import('https://cdn.skypack.dev/canvas-confetti');
confetti();

stack(
  "<C^7 F^7 ~> <Dm7 G7 A7 ~>"
   .every(2, fast(2))
   .voicings(),
  "<c2 f2 g2> <d2 g2 a2 e2>"
).transpose("<0 2 3 4>")
```