### PR TITLE
add support for legato to the mininotation

### DIFF
--- a/packages/mini/krill-parser.js
+++ b/packages/mini/krill-parser.js
@@ -195,20 +195,22 @@ function peg$parse(input, options) {
   var peg$c21 = "*";
   var peg$c22 = "%";
   var peg$c23 = "?";
-  var peg$c24 = "struct";
-  var peg$c25 = "target";
-  var peg$c26 = "euclid";
-  var peg$c27 = "slow";
-  var peg$c28 = "rotL";
-  var peg$c29 = "rotR";
-  var peg$c30 = "fast";
-  var peg$c31 = "scale";
-  var peg$c32 = "//";
-  var peg$c33 = "cat";
-  var peg$c34 = "$";
-  var peg$c35 = "setcps";
-  var peg$c36 = "setbpm";
-  var peg$c37 = "hush";
+  var peg$c24 = "=";
+  var peg$c25 = "struct";
+  var peg$c26 = "target";
+  var peg$c27 = "euclid";
+  var peg$c28 = "slow";
+  var peg$c29 = "rotL";
+  var peg$c30 = "rotR";
+  var peg$c31 = "fast";
+  var peg$c32 = "scale";
+  var peg$c33 = "legato";
+  var peg$c34 = "//";
+  var peg$c35 = "cat";
+  var peg$c36 = "$";
+  var peg$c37 = "setcps";
+  var peg$c38 = "setbpm";
+  var peg$c39 = "hush";
 
   var peg$r0 = /^[1-9]/;
   var peg$r1 = /^[eE]/;
@@ -248,21 +250,23 @@ function peg$parse(input, options) {
   var peg$e28 = peg$literalExpectation("*", false);
   var peg$e29 = peg$literalExpectation("%", false);
   var peg$e30 = peg$literalExpectation("?", false);
-  var peg$e31 = peg$literalExpectation("struct", false);
-  var peg$e32 = peg$literalExpectation("target", false);
-  var peg$e33 = peg$literalExpectation("euclid", false);
-  var peg$e34 = peg$literalExpectation("slow", false);
-  var peg$e35 = peg$literalExpectation("rotL", false);
-  var peg$e36 = peg$literalExpectation("rotR", false);
-  var peg$e37 = peg$literalExpectation("fast", false);
-  var peg$e38 = peg$literalExpectation("scale", false);
-  var peg$e39 = peg$literalExpectation("//", false);
-  var peg$e40 = peg$classExpectation(["\n"], true, false);
-  var peg$e41 = peg$literalExpectation("cat", false);
-  var peg$e42 = peg$literalExpectation("$", false);
-  var peg$e43 = peg$literalExpectation("setcps", false);
-  var peg$e44 = peg$literalExpectation("setbpm", false);
-  var peg$e45 = peg$literalExpectation("hush", false);
+  var peg$e31 = peg$literalExpectation("=", false);
+  var peg$e32 = peg$literalExpectation("struct", false);
+  var peg$e33 = peg$literalExpectation("target", false);
+  var peg$e34 = peg$literalExpectation("euclid", false);
+  var peg$e35 = peg$literalExpectation("slow", false);
+  var peg$e36 = peg$literalExpectation("rotL", false);
+  var peg$e37 = peg$literalExpectation("rotR", false);
+  var peg$e38 = peg$literalExpectation("fast", false);
+  var peg$e39 = peg$literalExpectation("scale", false);
+  var peg$e40 = peg$literalExpectation("legato", false);
+  var peg$e41 = peg$literalExpectation("//", false);
+  var peg$e42 = peg$classExpectation(["\n"], true, false);
+  var peg$e43 = peg$literalExpectation("cat", false);
+  var peg$e44 = peg$literalExpectation("$", false);
+  var peg$e45 = peg$literalExpectation("setcps", false);
+  var peg$e46 = peg$literalExpectation("setbpm", false);
+  var peg$e47 = peg$literalExpectation("hush", false);
 
   var peg$f0 = function() { return parseFloat(text()); };
   var peg$f1 = function(chars) { return chars.join("") };
@@ -275,29 +279,31 @@ function peg$parse(input, options) {
   var peg$f8 = function(a) { return { operator : { type_: "stretch", arguments_ :{ amount:"1/"+a } } } };
   var peg$f9 = function(a) { return { operator : { type_: "fixed-step", arguments_ :{ amount:a } } } };
   var peg$f10 = function(a) { return { operator : { type_: "degradeBy", arguments_ :{ amount:(a? a : 0.5) } } } };
-  var peg$f11 = function(s, o) { return new ElementStub(s, o);};
-  var peg$f12 = function(s) { return new PatternStub(s,"h"); };
-  var peg$f13 = function(tail) { return { alignment: 'v', list: tail }; };
-  var peg$f14 = function(tail) { return { alignment: 'r', list: tail }; };
-  var peg$f15 = function(head, tail) { if (tail && tail.list.length > 0) { return new PatternStub([head, ...tail.list], tail.alignment); } else { return head; } };
-  var peg$f16 = function(sc) { return sc; };
-  var peg$f17 = function(s) { return { name: "struct", args: { sequence:s }}};
-  var peg$f18 = function(s) { return { name: "target", args : { name:s}}};
-  var peg$f19 = function(p, s, r) { return { name: "bjorklund", args :{ pulse: parseInt(p), step:parseInt(s) }}};
-  var peg$f20 = function(a) { return { name: "stretch", args :{ amount: a}}};
-  var peg$f21 = function(a) { return { name: "shift", args :{ amount: "-"+a}}};
-  var peg$f22 = function(a) { return { name: "shift", args :{ amount: a}}};
-  var peg$f23 = function(a) { return { name: "stretch", args :{ amount: "1/"+a}}};
-  var peg$f24 = function(s) { return { name: "scale", args :{ scale: s.join("")}}};
-  var peg$f25 = function(s, v) { return v};
-  var peg$f26 = function(s, ss) { ss.unshift(s); return new PatternStub(ss,"t"); };
-  var peg$f27 = function(sg) {return sg};
-  var peg$f28 = function(o, soc) { return new OperatorStub(o.name,o.args,soc)};
-  var peg$f29 = function(sc) { return sc };
-  var peg$f30 = function(c) { return c };
-  var peg$f31 = function(v) { return new CommandStub("setcps", { value: v})};
-  var peg$f32 = function(v) { return new CommandStub("setcps", { value: (v/120/2)})};
-  var peg$f33 = function() { return new CommandStub("hush")};
+  var peg$f11 = function(a) { return { operator : { type_: "legato", arguments_: { amount:a } } } };
+  var peg$f12 = function(s, o) { return new ElementStub(s, o);};
+  var peg$f13 = function(s) { return new PatternStub(s,"h"); };
+  var peg$f14 = function(tail) { return { alignment: 'v', list: tail }; };
+  var peg$f15 = function(tail) { return { alignment: 'r', list: tail }; };
+  var peg$f16 = function(head, tail) { if (tail && tail.list.length > 0) { return new PatternStub([head, ...tail.list], tail.alignment); } else { return head; } };
+  var peg$f17 = function(sc) { return sc; };
+  var peg$f18 = function(s) { return { name: "struct", args: { sequence:s }}};
+  var peg$f19 = function(s) { return { name: "target", args : { name:s}}};
+  var peg$f20 = function(p, s, r) { return { name: "bjorklund", args :{ pulse: parseInt(p), step:parseInt(s) }}};
+  var peg$f21 = function(a) { return { name: "stretch", args :{ amount: a}}};
+  var peg$f22 = function(a) { return { name: "shift", args :{ amount: "-"+a}}};
+  var peg$f23 = function(a) { return { name: "shift", args :{ amount: a}}};
+  var peg$f24 = function(a) { return { name: "stretch", args :{ amount: "1/"+a}}};
+  var peg$f25 = function(s) { return { name: "scale", args :{ scale: s.join("")}}};
+  var peg$f26 = function(a) { return { name: "legato", args :{ amount: a}}};
+  var peg$f27 = function(s, v) { return v};
+  var peg$f28 = function(s, ss) { ss.unshift(s); return new PatternStub(ss,"t"); };
+  var peg$f29 = function(sg) {return sg};
+  var peg$f30 = function(o, soc) { return new OperatorStub(o.name,o.args,soc)};
+  var peg$f31 = function(sc) { return sc };
+  var peg$f32 = function(c) { return c };
+  var peg$f33 = function(v) { return new CommandStub("setcps", { value: v})};
+  var peg$f34 = function(v) { return new CommandStub("setcps", { value: (v/120/2)})};
+  var peg$f35 = function() { return new CommandStub("hush")};
   var peg$currPos = 0;
   var peg$savedPos = 0;
   var peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -1000,6 +1006,9 @@ function peg$parse(input, options) {
               s0 = peg$parseslice_replicate();
               if (s0 === peg$FAILED) {
                 s0 = peg$parseslice_degrade();
+                if (s0 === peg$FAILED) {
+                  s0 = peg$parseslice_legato();
+                }
               }
             }
           }
@@ -1242,6 +1251,34 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseslice_legato() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 61) {
+      s1 = peg$c24;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e31); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsenumber();
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f11(s2);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseslice_with_modifier() {
     var s0, s1, s2;
 
@@ -1253,7 +1290,7 @@ function peg$parse(input, options) {
         s2 = null;
       }
       peg$savedPos = s0;
-      s0 = peg$f11(s1, s2);
+      s0 = peg$f12(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1278,7 +1315,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f12(s1);
+      s1 = peg$f13(s1);
     }
     s0 = s1;
 
@@ -1327,7 +1364,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f13(s1);
+      s1 = peg$f14(s1);
     }
     s0 = s1;
 
@@ -1376,7 +1413,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f14(s1);
+      s1 = peg$f15(s1);
     }
     s0 = s1;
 
@@ -1397,7 +1434,7 @@ function peg$parse(input, options) {
         s2 = null;
       }
       peg$savedPos = s0;
-      s0 = peg$f15(s1, s2);
+      s0 = peg$f16(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1418,7 +1455,7 @@ function peg$parse(input, options) {
         s4 = peg$parsequote();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f16(s3);
+          s0 = peg$f17(s3);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1453,6 +1490,9 @@ function peg$parse(input, options) {
                 s0 = peg$parserotR();
                 if (s0 === peg$FAILED) {
                   s0 = peg$parserotL();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parselegato();
+                  }
                 }
               }
             }
@@ -1468,19 +1508,19 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c24) {
-      s1 = peg$c24;
+    if (input.substr(peg$currPos, 6) === peg$c25) {
+      s1 = peg$c25;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e31); }
+      if (peg$silentFails === 0) { peg$fail(peg$e32); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsews();
       s3 = peg$parsesequence_or_operator();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f17(s3);
+        s0 = peg$f18(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1497,12 +1537,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c25) {
-      s1 = peg$c25;
+    if (input.substr(peg$currPos, 6) === peg$c26) {
+      s1 = peg$c26;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e32); }
+      if (peg$silentFails === 0) { peg$fail(peg$e33); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsews();
@@ -1513,7 +1553,7 @@ function peg$parse(input, options) {
           s5 = peg$parsequote();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f18(s4);
+            s0 = peg$f19(s4);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1538,12 +1578,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c26) {
-      s1 = peg$c26;
+    if (input.substr(peg$currPos, 6) === peg$c27) {
+      s1 = peg$c27;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e33); }
+      if (peg$silentFails === 0) { peg$fail(peg$e34); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsews();
@@ -1558,7 +1598,7 @@ function peg$parse(input, options) {
             s7 = null;
           }
           peg$savedPos = s0;
-          s0 = peg$f19(s3, s5, s7);
+          s0 = peg$f20(s3, s5, s7);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1576,35 +1616,6 @@ function peg$parse(input, options) {
   }
 
   function peg$parseslow() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c27) {
-      s1 = peg$c27;
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e34); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parsews();
-      s3 = peg$parsenumber();
-      if (s3 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f20(s3);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parserotL() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -1633,7 +1644,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parserotR() {
+  function peg$parserotL() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -1662,7 +1673,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsefast() {
+  function peg$parserotR() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -1691,16 +1702,45 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsefast() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4) === peg$c31) {
+      s1 = peg$c31;
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e38); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsews();
+      s3 = peg$parsenumber();
+      if (s3 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f24(s3);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parsescale() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c31) {
-      s1 = peg$c31;
+    if (input.substr(peg$currPos, 5) === peg$c32) {
+      s1 = peg$c32;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e38); }
+      if (peg$silentFails === 0) { peg$fail(peg$e39); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsews();
@@ -1720,7 +1760,7 @@ function peg$parse(input, options) {
           s5 = peg$parsequote();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f24(s4);
+            s0 = peg$f25(s4);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1741,16 +1781,45 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parselegato() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6) === peg$c33) {
+      s1 = peg$c33;
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e40); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsews();
+      s3 = peg$parsenumber();
+      if (s3 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f26(s3);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parsecomment() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c32) {
-      s1 = peg$c32;
+    if (input.substr(peg$currPos, 2) === peg$c34) {
+      s1 = peg$c34;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e39); }
+      if (peg$silentFails === 0) { peg$fail(peg$e41); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1759,7 +1828,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e40); }
+        if (peg$silentFails === 0) { peg$fail(peg$e42); }
       }
       while (s3 !== peg$FAILED) {
         s2.push(s3);
@@ -1768,7 +1837,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e40); }
+          if (peg$silentFails === 0) { peg$fail(peg$e42); }
         }
       }
       s1 = [s1, s2];
@@ -1785,12 +1854,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c33) {
-      s1 = peg$c33;
+    if (input.substr(peg$currPos, 3) === peg$c35) {
+      s1 = peg$c35;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e41); }
+      if (peg$silentFails === 0) { peg$fail(peg$e43); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsews();
@@ -1812,7 +1881,7 @@ function peg$parse(input, options) {
             s9 = peg$parsesequence_or_operator();
             if (s9 !== peg$FAILED) {
               peg$savedPos = s7;
-              s7 = peg$f25(s5, s9);
+              s7 = peg$f27(s5, s9);
             } else {
               peg$currPos = s7;
               s7 = peg$FAILED;
@@ -1829,7 +1898,7 @@ function peg$parse(input, options) {
               s9 = peg$parsesequence_or_operator();
               if (s9 !== peg$FAILED) {
                 peg$savedPos = s7;
-                s7 = peg$f25(s5, s9);
+                s7 = peg$f27(s5, s9);
               } else {
                 peg$currPos = s7;
                 s7 = peg$FAILED;
@@ -1849,7 +1918,7 @@ function peg$parse(input, options) {
           }
           if (s8 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f26(s5, s6);
+            s0 = peg$f28(s5, s6);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1895,7 +1964,7 @@ function peg$parse(input, options) {
         s4 = peg$parsecomment();
       }
       peg$savedPos = s0;
-      s0 = peg$f27(s1);
+      s0 = peg$f29(s1);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1906,18 +1975,18 @@ function peg$parse(input, options) {
       if (s1 !== peg$FAILED) {
         s2 = peg$parsews();
         if (input.charCodeAt(peg$currPos) === 36) {
-          s3 = peg$c34;
+          s3 = peg$c36;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e42); }
+          if (peg$silentFails === 0) { peg$fail(peg$e44); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parsews();
           s5 = peg$parsesequence_or_operator();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f28(s1, s5);
+            s0 = peg$f30(s1, s5);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1942,7 +2011,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesequence_or_operator();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f29(s1);
+      s1 = peg$f31(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1975,7 +2044,7 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       s3 = peg$parsews();
       peg$savedPos = s0;
-      s0 = peg$f30(s2);
+      s0 = peg$f32(s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1988,19 +2057,19 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c35) {
-      s1 = peg$c35;
+    if (input.substr(peg$currPos, 6) === peg$c37) {
+      s1 = peg$c37;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e43); }
+      if (peg$silentFails === 0) { peg$fail(peg$e45); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsews();
       s3 = peg$parsenumber();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f31(s3);
+        s0 = peg$f33(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2017,19 +2086,19 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c36) {
-      s1 = peg$c36;
+    if (input.substr(peg$currPos, 6) === peg$c38) {
+      s1 = peg$c38;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e44); }
+      if (peg$silentFails === 0) { peg$fail(peg$e46); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsews();
       s3 = peg$parsenumber();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f32(s3);
+        s0 = peg$f34(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2046,16 +2115,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c37) {
-      s1 = peg$c37;
+    if (input.substr(peg$currPos, 4) === peg$c39) {
+      s1 = peg$c39;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e45); }
+      if (peg$silentFails === 0) { peg$fail(peg$e47); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f33();
+      s1 = peg$f35();
     }
     s0 = s1;
 

--- a/packages/mini/krill.pegjs
+++ b/packages/mini/krill.pegjs
@@ -104,7 +104,7 @@ slice = step / sub_cycle  / timeline
 
 // slice modifier affects the timing/size of a slice (e.g. [a b c]@3)
 // at this point, we assume we can represent them as regular sequence operators
-slice_modifier = slice_weight / slice_bjorklund / slice_slow / slice_fast / slice_fixed_step / slice_replicate / slice_degrade
+slice_modifier = slice_weight / slice_bjorklund / slice_slow / slice_fast / slice_fixed_step / slice_replicate / slice_degrade / slice_legato
 
 slice_weight =  "@" a:number
   { return { weight: a} }
@@ -126,6 +126,9 @@ slice_fixed_step = "%"a:number
 
 slice_degrade = "?"a:number?
   { return { operator : { type_: "degradeBy", arguments_ :{ amount:(a? a : 0.5) } } } }
+
+slice_legato = "="a:number
+  { return { operator : { type_: "legato", arguments_: { amount:a } } } }
 
 // a slice with an modifier applied i.e [bd@4 sd@3]@2 hh]
 slice_with_modifier = s:slice o:slice_modifier?
@@ -156,7 +159,7 @@ sequence = ws quote sc:stack_or_choose quote
 
 // ------------------ operators ---------------------------
 
-operator = scale / slow / fast / target / bjorklund / struct / rotR / rotL
+operator = scale / slow / fast / target / bjorklund / struct / rotR / rotL / legato
 
 struct = "struct" ws s:sequence_or_operator
   { return { name: "struct", args: { sequence:s }}}
@@ -181,6 +184,9 @@ fast = "fast" ws a:number
 
 scale = "scale" ws quote s:(step_char)+ quote
 { return { name: "scale", args :{ scale: s.join("")}}}
+
+legato = "legato" ws a:number
+  { return { name: "legato", args :{ amount: a}}}
 
 comment = '//' p:([^\n]*)
 

--- a/packages/mini/mini.mjs
+++ b/packages/mini/mini.mjs
@@ -30,6 +30,8 @@ const applyOptions = (parent) => (pat, i) => {
         return pat.euclid(operator.arguments_.pulse, operator.arguments_.step, operator.arguments_.rotation);
       case 'degradeBy':
         return reify(pat)._degradeByWith(strudel.rand.early(randOffset * _nextSeed()).segment(1), operator.arguments_.amount);
+      case 'legato':
+        return reify(pat).legato(operator.arguments_.amount);
       // TODO: case 'fixed-step': "%"
     }
     console.warn(`operator "${operator.type_}" not implemented`);

--- a/packages/mini/test/mini.test.mjs
+++ b/packages/mini/test/mini.test.mjs
@@ -104,4 +104,8 @@ describe('mini', () => {
     expect(chisq <= 15.086).toBe(true);
     // assert(chisq <= 15.086, chisq + ' was expected to be less than 15.086 under chi-squared test');
   });
+  it('supports the = operator for legato', () => {
+    expect(minS('a=0.8')).toEqual(mini('a').legato(0.8)._showFirstCycle);
+    expect(minS('a5=1.5 ~ b5=0.5 ~')).toEqual(['a5: 0 - 3/8', 'b5: 1/2 - 5/8']);
+  });
 });


### PR DESCRIPTION
I just found out about `legato`!

It's pretty cool, and it could be a lot easier to express staccato that way as opposed to shortening durations and following up with rests of exactly the right size. However, there's no support for it in the mininotation, so here's a proposal.

For instance, you could do something like `"[a4 c5 e5]=0.5 [a5 e5 c5]"`

**Note:** the mini-notation is rapidly running out of sigils to use for different operators, I went with `=` for now, but that might bear some discussion since `=` has been mentioned as a possibility to use for notes held over after a tie. It looks like maybe `&` and `$` may be still available...