### PR TITLE
Object arithmetic

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -40,11 +40,6 @@ const generic_params = [
    * @example
    * n("0 1 2 3").s('east').osc()
    */
-  // TODO: nOut does not work
-  // TODO: notes don't work as expected
-  // current "workaround" for notes:
-  // s('superpiano').n("<c0 d0 e0 g0>"._asNumber()).osc()
-  // -> .n or .osc (or .superdirt) would need to convert note strings to numbers
   // also see https://github.com/tidalcycles/strudel/pull/63
   ['f', 'n', 'The note or sample number to choose for a synth or sampleset'],
   ['f', 'note', 'The note or pitch to play a sound or synth with'],

--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -446,39 +446,8 @@ export class Pattern {
     return otherPat.fmap((b) => this.fmap((a) => func(a)(b)))._TrigzeroJoin();
   }
 
-  // TODO: refactor to parseNumber / withNumberArgs (see util)
-  _asNumber(dropfails = false, softfail = false) {
-    return this._withHap((hap) => {
-      // leave objects alone... this is needed to be able to do pat.add(n(2))
-      if (!['number', 'string'].includes(typeof hap.value)) {
-        return hap;
-      }
-      const asNumber = Number(hap.value);
-      if (!isNaN(asNumber)) {
-        return hap.withValue(() => asNumber);
-      }
-      const specialValue = {
-        e: Math.E,
-        pi: Math.PI,
-      }[hap.value];
-      if (typeof specialValue !== 'undefined') {
-        return hap.withValue(() => specialValue);
-      }
-      if (isNote(hap.value)) {
-        // set context type to midi to let the player know its meant as midi number and not as frequency
-        return new Hap(hap.whole, hap.part, toMidi(hap.value), { ...hap.context, type: 'midi' });
-      }
-      if (dropfails) {
-        // return 'nothing'
-        return undefined;
-      }
-      if (softfail) {
-        // return original hap
-        return hap;
-      }
-      throw new Error('cannot parse as number: "' + hap.value + '"');
-      return hap;
-    });
+  _asNumber() {
+    return this.fmap(numeralArgs);
   }
 
   /**

--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -1391,9 +1391,6 @@ function _composeOp(a, b, func) {
 
 // Make composers
 (function () {
-  const num = (pat) => pat._asNumber();
-  // const numOrString = (pat) => pat._asNumber(false, true); // was used for add
-
   // pattern composers
   const composers = {
     set: [(a, b) => b],
@@ -1417,7 +1414,7 @@ function _composeOp(a, b, func) {
      * // Behind the scenes, the notes are converted to midi numbers:
      * // "48 52 55".add("<0 5 7 0>").note()
      */
-    add: [numeralArgs((a, b) => a + b), num], // support string concatenation
+    add: [numeralArgs((a, b) => a + b)], // support string concatenation
     /**
      *
      * Like add, but the given numbers are subtracted.
@@ -1427,7 +1424,7 @@ function _composeOp(a, b, func) {
      * "0 2 4".sub("<0 1 2 3>").scale('C4 minor').note()
      * // See add for more information.
      */
-    sub: [numeralArgs((a, b) => a - b), num],
+    sub: [numeralArgs((a, b) => a - b)],
     /**
      *
      * Multiplies each number by the given factor.
@@ -1436,21 +1433,21 @@ function _composeOp(a, b, func) {
      * @example
      * "1 1.5 [1.66, <2 2.33>]".mul(150).freq()
      */
-    mul: [numeralArgs((a, b) => a * b), num],
+    mul: [numeralArgs((a, b) => a * b)],
     /**
      *
      * Divides each number by the given factor.
      * @name div
      * @memberof Pattern
      */
-    div: [numeralArgs((a, b) => a / b), num],
-    mod: [mod, num],
-    pow: [Math.pow, num],
-    _and: [(a, b) => a & b, num],
-    _or: [(a, b) => a | b, num],
-    _xor: [(a, b) => a ^ b, num],
-    _lshift: [(a, b) => a << b, num],
-    _rshift: [(a, b) => a >> b, num],
+    div: [numeralArgs((a, b) => a / b)],
+    mod: [numeralArgs(mod)],
+    pow: [numeralArgs(Math.pow)],
+    _and: [numeralArgs((a, b) => a & b)],
+    _or: [numeralArgs((a, b) => a | b)],
+    _xor: [numeralArgs((a, b) => a ^ b)],
+    _lshift: [numeralArgs((a, b) => a << b)],
+    _rshift: [numeralArgs((a, b) => a >> b)],
 
     // TODO - force numerical comparison if both look like numbers?
     lt: [(a, b) => a < b],

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -238,6 +238,7 @@ export const wchoose = (...pairs) => wchooseWith(rand, ...pairs);
 
 export const wchooseCycles = (...pairs) => _wchooseWith(rand, ...pairs).innerJoin();
 
+// this function expects pat to be a pattern of floats...
 export const perlinWith = (pat) => {
   const pata = pat.fmap(Math.floor);
   const patb = pat.fmap((t) => Math.floor(t) + 1);
@@ -255,7 +256,7 @@ export const perlinWith = (pat) => {
  * s("bd sd,hh*4").cutoff(perlin.range(500,2000))
  *
  */
-export const perlin = perlinWith(time);
+export const perlin = perlinWith(time.fmap((v) => Number(v)));
 
 Pattern.prototype._degradeByWith = function (withPat, x) {
   return this.fmap((a) => (_) => a).appLeft(withPat._filterValues((v) => v > x));

--- a/packages/core/test/pattern.test.mjs
+++ b/packages/core/test/pattern.test.mjs
@@ -47,6 +47,9 @@ import {
 
 import { steady } from '../signal.mjs';
 
+import controls from '../controls.mjs';
+
+const { n } = controls;
 const st = (begin, end) => new State(ts(begin, end));
 const ts = (begin, end) => new TimeSpan(Fraction(begin), Fraction(end));
 const hap = (whole, part, value, context = {}) => new Hap(whole, part, value, context);
@@ -138,7 +141,7 @@ describe('Pattern', () => {
       expect(pure('hello').query(st(0.5, 2.5)).length).toBe(3);
     });
     it('Supports zero-width queries', () => {
-      expect(pure('hello').queryArc(0,0).length).toBe(1);
+      expect(pure('hello').queryArc(0, 0).length).toBe(1);
     });
   });
   describe('fmap()', () => {
@@ -193,6 +196,9 @@ describe('Pattern', () => {
         sequence(1, [2, 3]).addSqueezeOut(10, 20, 30),
         sequence([11, [12, 13]], [21, [22, 23]], [31, [32, 33]]),
       );
+    });
+    it('can add object patterns', () => {
+      sameFirst(n(sequence(1, [2, 3])).add(n(10)), n(sequence(11, [12, 13])));
     });
   });
   describe('keep()', () => {
@@ -376,9 +382,10 @@ describe('Pattern', () => {
       );
     });
     it('copes with breaking up events across cycles', () => {
-      expect(pure('a').slow(2)._fastGap(2)._setContext({}).query(st(0, 2))).toStrictEqual(
-        [hap(ts(0, 1), ts(0, 0.5), 'a'), hap(ts(0.5, 1.5), ts(1, 1.5), 'a')]
-      );
+      expect(pure('a').slow(2)._fastGap(2)._setContext({}).query(st(0, 2))).toStrictEqual([
+        hap(ts(0, 1), ts(0, 0.5), 'a'),
+        hap(ts(0.5, 1.5), ts(1, 1.5), 'a'),
+      ]);
     });
   });
   describe('_compressSpan()', () => {
@@ -434,14 +441,14 @@ describe('Pattern', () => {
       // mini('eb3 [c3 g3]/2 ') always plays [c3 g3]
     });
     it('Supports zero-length queries', () => {
-      expect(steady('a')._slow(1).queryArc(0,0)
-	    ).toStrictEqual(steady('a').queryArc(0,0))
+      expect(steady('a')._slow(1).queryArc(0, 0)).toStrictEqual(steady('a').queryArc(0, 0));
     });
   });
   describe('slow()', () => {
     it('Supports zero-length queries', () => {
-      expect(steady('a').slow(1)._setContext({}).queryArc(0,0)
-	    ).toStrictEqual(steady('a')._setContext({}).queryArc(0,0))
+      expect(steady('a').slow(1)._setContext({}).queryArc(0, 0)).toStrictEqual(
+        steady('a')._setContext({}).queryArc(0, 0),
+      );
     });
   });
   describe('inside', () => {
@@ -812,10 +819,11 @@ describe('Pattern', () => {
     });
     it('Squeezes to the correct cycle', () => {
       expect(
-        pure(time.struct(true))._squeezeJoin().queryArc(3,4).map(x => x.value)
-      ).toStrictEqual(
-        [Fraction(3.5)]
-      )
+        pure(time.struct(true))
+          ._squeezeJoin()
+          .queryArc(3, 4)
+          .map((x) => x.value),
+      ).toStrictEqual([Fraction(3.5)]);
     });
   });
   describe('ply', () => {
@@ -868,9 +876,7 @@ describe('Pattern', () => {
   });
   describe('range', () => {
     it('Can be patterned', () => {
-      expect(sequence(0, 0).range(sequence(0, 0.5), 1).firstCycle()).toStrictEqual(
-        sequence(0, 0.5).firstCycle(),
-      );
+      expect(sequence(0, 0).range(sequence(0, 0.5), 1).firstCycle()).toStrictEqual(sequence(0, 0.5).firstCycle());
     });
   });
   describe('range2', () => {

--- a/packages/core/test/util.test.mjs
+++ b/packages/core/test/util.test.mjs
@@ -15,6 +15,7 @@ import {
   getFrequency,
   getPlayableNoteValue,
   parseNumeral,
+  parseFractional,
   numeralArgs,
   fractionalArgs,
 } from '../util.mjs';

--- a/packages/core/util.mjs
+++ b/packages/core/util.mjs
@@ -130,3 +130,46 @@ export function curry(func, overload) {
   }
   return fn;
 }
+
+export function parseNumeral(numOrString) {
+  const asNumber = Number(numOrString);
+  if (!isNaN(asNumber)) {
+    return asNumber;
+  }
+  if (isNote(numOrString)) {
+    return toMidi(numOrString);
+  }
+  throw new Error(`cannot parse as numeral: "${numOrString}"`);
+}
+
+export function mapArgs(fn, mapFn) {
+  return (...args) => fn(...args.map(mapFn));
+}
+
+export function numeralArgs(fn) {
+  return mapArgs(fn, parseNumeral);
+}
+
+export function parseFractional(numOrString) {
+  const asNumber = Number(numOrString);
+  if (!isNaN(asNumber)) {
+    return asNumber;
+  }
+  const specialValue = {
+    pi: Math.PI,
+    w: 1,
+    h: 0.5,
+    q: 0.25,
+    e: 0.125,
+    s: 0.0625,
+    t: 1 / 3,
+    f: 0.2,
+    x: 1 / 6,
+  }[numOrString];
+  if (typeof specialValue !== 'undefined') {
+    return specialValue;
+  }
+  throw new Error(`cannot parse as fractional: "${numOrString}"`);
+}
+
+export const fractionalArgs = (fn) => mapArgs(fn, parseFractional);

--- a/packages/osc/osc.mjs
+++ b/packages/osc/osc.mjs
@@ -5,7 +5,7 @@ This program is free software: you can redistribute it and/or modify it under th
 */
 
 import OSC from 'osc-js';
-import { Pattern } from '@strudel.cycles/core';
+import { parseNumeral, Pattern } from '@strudel.cycles/core';
 
 const comm = new OSC();
 comm.open();
@@ -31,6 +31,10 @@ Pattern.prototype.osc = function () {
         startedAt = Date.now() - currentTime * 1000;
       }
       const controls = Object.assign({}, { cps, cycle, delta }, hap.value);
+      // make sure n and note are numbers
+      controls.n && (controls.n = parseNumeral(controls.n));
+      controls.note && (controls.note = parseNumeral(controls.note));
+
       const keyvals = Object.entries(controls).flat();
       const ts = Math.floor(startedAt + (time + latency) * 1000);
       const message = new OSC.Message('/dirt/play', ...keyvals);


### PR DESCRIPTION
with this PR, it's now possible to do things like:

```js
n("c3").add(n(2))
n("c3 f3").off(1/4, add(n(12)))
s("hh*2").speed("1 1.2").off(1/8, add(speed(.2)))
```

This did not work before because the number conversion was not working for objects. I changed it so that the conversion happens after all that object stuff, right before the arithmetic functions are called. I also simplified asNumber, because it is now not needed as often.