### PR TITLE
Load samples from url

### DIFF
--- a/packages/webaudio/sampler.mjs
+++ b/packages/webaudio/sampler.mjs
@@ -102,7 +102,13 @@ export const loadGithubSamples = async (path, nameFn) => {
  *
  */
 
-export const samples = (sampleMap, baseUrl = sampleMap._base || '') => {
+export const samples = async (sampleMap, baseUrl = sampleMap._base || '') => {
+  if (typeof sampleMap === 'string') {
+    const base = sampleMap.split('/').slice(0, -1).join('/');
+    return fetch(sampleMap)
+      .then((res) => res.json())
+      .then((json) => samples(json, json._base || base));
+  }
   sampleCache.current = {
     ...sampleCache.current,
     ...Object.fromEntries(

--- a/packages/webaudio/sampler.mjs
+++ b/packages/webaudio/sampler.mjs
@@ -107,7 +107,7 @@ export const samples = async (sampleMap, baseUrl = sampleMap._base || '') => {
     const base = sampleMap.split('/').slice(0, -1).join('/');
     return fetch(sampleMap)
       .then((res) => res.json())
-      .then((json) => samples(json, json._base || base));
+      .then((json) => samples(json, baseUrl || json._base || base));
   }
   sampleCache.current = {
     ...sampleCache.current,

--- a/repl/src/prebake.mjs
+++ b/repl/src/prebake.mjs
@@ -1,23 +1,17 @@
 import { Pattern, toMidi } from '@strudel.cycles/core';
 import { samples } from '@strudel.cycles/webaudio';
 
-const loadSamples = async (url, baseDir = '') => {
-  await fetch(url)
-    .then((res) => res.json())
-    .then((json) => samples(json, baseDir));
-};
-
 export async function prebake({ isMock = false, baseDir = '.' } = {}) {
   if (!isMock) {
     // https://archive.org/details/SalamanderGrandPianoV3
     // License: CC-by http://creativecommons.org/licenses/by/3.0/ Author: Alexander Holm
-    loadSamples('piano.json', `${baseDir}/piano/`);
+    samples('piano.json', `${baseDir}/piano/`);
     // https://github.com/sgossner/VCSL/
     // https://api.github.com/repositories/126427031/contents/
     // LICENSE: CC0 general-purpose
-    loadSamples('vcsl.json', 'github:sgossner/VCSL/master/');
-    loadSamples('tidal-drum-machines.json', 'github:ritchse/tidal-drum-machines/main/machines/');
-    loadSamples('EmuSP12.json', `${baseDir}/EmuSP12/`);
+    samples('vcsl.json', 'github:sgossner/VCSL/master/');
+    samples('tidal-drum-machines.json', 'github:ritchse/tidal-drum-machines/main/machines/');
+    samples('EmuSP12.json', `${baseDir}/EmuSP12/`);
   }
 }
 


### PR DESCRIPTION
can now use the `samples` function with a url that points to a json file, e.g.

```js
samples('https://gist.githubusercontent.com/felixroos/b9d461966ae1aaa660beea7c61482d21/raw/dirt-samples.json')
```

this allows loading custom sample sets more easily