### PR TITLE
feat: support github: links

### DIFF
--- a/packages/webaudio/sampler.mjs
+++ b/packages/webaudio/sampler.mjs
@@ -104,10 +104,18 @@ export const loadGithubSamples = async (path, nameFn) => {
 
 export const samples = async (sampleMap, baseUrl = sampleMap._base || '') => {
   if (typeof sampleMap === 'string') {
+    if (sampleMap.startsWith('github:')) {
+      const [_, path] = sampleMap.split('github:');
+      sampleMap = `https://raw.githubusercontent.com/${path}/strudel.json`;
+    }
     const base = sampleMap.split('/').slice(0, -1).join('/');
     return fetch(sampleMap)
       .then((res) => res.json())
-      .then((json) => samples(json, baseUrl || json._base || base));
+      .then((json) => samples(json, baseUrl || json._base || base))
+      .catch((error) => {
+        console.error(error);
+        throw new Error(`error loading "${sampleMap}"`);
+      });
   }
   sampleCache.current = {
     ...sampleCache.current,


### PR DESCRIPTION
can now load samples via `github:user/repo/branch` shortcut, expecting a `strudel.json` to be present at the given path.
This makes it easier to load custom sample packs without needing some intermediate json file somewhere 