### PR TITLE
Webaudio build

### DIFF
--- a/packages/core/examples/vanilla.html
+++ b/packages/core/examples/vanilla.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Buildless Vanilla Strudel REPL</title>
+  </head>
+  <body style="margin: 0; background: #222">
+    <div style="display: grid; height: 100vh">
+      <textarea
+        id="text"
+        style="font-size: 2em; border: 0; color: white; background: transparent; outline: none; padding: 20px"
+        spellcheck="false"
+      ></textarea>
+    </div>
+    <button
+      id="start"
+      style="
+        position: absolute;
+        border-radius: 10px;
+        top: 20px;
+        right: 20px;
+        padding: 20px;
+        border: 2px solid white;
+        background: transparent;
+        color: white;
+        cursor: pointer;
+      "
+    >
+      evaluate
+    </button>
+    <div id="output"></div>
+    <script type="module">
+      import { controls, repl, evalScope } from 'https://cdn.skypack.dev/@strudel.cycles/core@0.3.2';
+      import { mini } from 'https://cdn.skypack.dev/@strudel.cycles/mini@0.3.2';
+      import { transpiler } from 'https://cdn.skypack.dev/@strudel.cycles/transpiler@0.3.2';
+      import { getAudioContext, webaudioOutput } from 'https://cdn.skypack.dev/@strudel.cycles/webaudio@0.3.3';
+
+      const ctx = getAudioContext();
+      const input = document.getElementById('text');
+      input.innerHTML = getTune();
+
+      evalScope(
+        controls,
+        import('https://cdn.skypack.dev/@strudel.cycles/core@0.3.2'),
+        import('https://cdn.skypack.dev/@strudel.cycles/mini@0.3.2'),
+        import('https://cdn.skypack.dev/@strudel.cycles/tonal@0.3.3'),
+        import('https://cdn.skypack.dev/@strudel.cycles/webaudio@0.3.3'),
+      );
+
+      const { evaluate } = repl({
+        defaultOutput: webaudioOutput,
+        getTime: () => ctx.currentTime,
+        transpiler,
+      });
+      document.getElementById('start').addEventListener('click', () => {
+        ctx.resume();
+        evaluate(input.value);
+      });
+
+      function getTune() {
+        return `await samples('github:tidalcycles/Dirt-Samples/master')
+
+stack(
+  // amen
+  n("0 1 2 3 4 5 6 7")
+  .sometimes(x=>x.ply(2))
+  .rarely(x=>x.speed("2 | -2"))
+  .sometimesBy(.4, x=>x.delay(".5"))
+  .s("amencutup")
+  .slow(2)
+  .room(.5)
+  ,
+  // bass
+  sine.add(saw.slow(4)).range(0,7).segment(8)
+  .superimpose(x=>x.add(.1))
+  .scale('G0 minor').note()
+  .s("sawtooth").decay(.1).sustain(0)
+  .gain(.4).cutoff(perlin.range(300,3000).slow(8)).resonance(10)
+  .degradeBy("0 0.1 .5 .1")
+  .rarely(add(note("12")))
+  ,
+  // chord
+  note("Bb3,D4".superimpose(x=>x.add(.2)))
+  .s('sawtooth').cutoff(1000).struct("<~@3 [~ x]>")
+  .decay(.05).sustain(.0).delay(.8).delaytime(.125).room(.8)
+  ,
+  // alien
+  s("breath").room(1).shape(.6).chop(16).rev().mask("<x ~@7>")
+  ,
+  n("0 1").s("east").delay(.5).degradeBy(.8).speed(rand.range(.5,1.5))
+).reset("<x@7 x(5,8)>")`;
+      }
+    </script>
+  </body>
+</html>

--- a/packages/soundfonts/package-lock.json
+++ b/packages/soundfonts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@strudel.cycles/soundfonts",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/soundfonts/package.json
+++ b/packages/soundfonts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strudel.cycles/soundfonts",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Soundsfont support for strudel",
   "main": "index.mjs",
   "type": "module",
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/tidalcycles/strudel#readme",
   "dependencies": {
     "@strudel.cycles/core": "^0.3.2",
-    "@strudel.cycles/webaudio": "^0.3.2",
+    "@strudel.cycles/webaudio": "^0.3.3",
     "sfumato": "^0.1.2",
     "soundfont2": "^0.4.0"
   },

--- a/packages/webaudio/package-lock.json
+++ b/packages/webaudio/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@strudel.cycles/webaudio",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/webaudio/package.json
+++ b/packages/webaudio/package.json
@@ -2,13 +2,16 @@
   "name": "@strudel.cycles/webaudio",
   "version": "0.3.2",
   "description": "Web Audio helpers for Strudel",
-  "main": "index.mjs",
+  "main": "dist/index.cjs.mjs",
+  "module": "dist/index.es.js",
   "type": "module",
   "directories": {
     "example": "examples"
   },
   "scripts": {
-    "example": "npx parcel examples/repl.html"
+    "example": "npx parcel examples/repl.html",
+    "build": "vite build",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/packages/webaudio/package.json
+++ b/packages/webaudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strudel.cycles/webaudio",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Web Audio helpers for Strudel",
   "main": "dist/index.cjs.mjs",
   "module": "dist/index.es.js",

--- a/packages/webaudio/package.json
+++ b/packages/webaudio/package.json
@@ -2,7 +2,7 @@
   "name": "@strudel.cycles/webaudio",
   "version": "0.3.3",
   "description": "Web Audio helpers for Strudel",
-  "main": "dist/index.cjs.mjs",
+  "main": "index.mjs",
   "module": "dist/index.es.js",
   "type": "module",
   "directories": {

--- a/packages/webaudio/vite.config.js
+++ b/packages/webaudio/vite.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import { dependencies } from './package.json';
+import { resolve } from 'path';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'index.mjs'),
+      formats: ['es', 'cjs'],
+      fileName: (ext) => `index.${ext}.js`,
+    },
+    rollupOptions: {
+      external: [...Object.keys(dependencies)],
+    },
+    target: 'esnext',
+  },
+});


### PR DESCRIPTION
adds a build task for the webaudio package, making sure it is importable. This is needed because it uses a special ?url syntax to import the audio worklet file, which is vite specific syntax. after the build, that file will be inlined as a base64.

edit: also added a new example "vanilla.html" that showcases how the strudel packages now work without a bundler, using skypack imports