### PR TITLE
fix performance bottleneck

### DIFF
--- a/packages/core/fraction.mjs
+++ b/packages/core/fraction.mjs
@@ -74,7 +74,7 @@ const fraction = (n) => {
     -> those farey sequences turn out to make pattern querying ~20 times slower! always use strings!
     -> still, some optimizations could be done: .mul .div .add .sub calls still use numbers
     */
-    n = String(n);
+    // n = String(n); // this is actually faster but imprecise...
   }
   return Fraction(n);
 };

--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -800,6 +800,7 @@ export class Pattern {
    * s("<bd sd> hh").fast(2) // s("[<bd sd> hh]*2")
    */
   _fast(factor) {
+    factor = Fraction(factor);
     const fastQuery = this.withQueryTime((t) => t.mul(factor));
     return fastQuery.withHapTime((t) => t.div(factor));
   }


### PR DESCRIPTION
in the _fast function, the float to fraction conversion ran way too often. This could lead to very long query execution times which ruined performance. see https://github.com/tidalcycles/strudel/issues/194 .