### PR TITLE
do not recompile orc

### DIFF
--- a/packages/csound/csound.mjs
+++ b/packages/csound/csound.mjs
@@ -113,7 +113,9 @@ export async function loadOrc(url) {
     url = `https://raw.githubusercontent.com/${path}`;
   }
   if (!orcCache[url]) {
-    orcCache[url] = await fetch(url).then((res) => res.text());
+    orcCache[url] = fetch(url)
+      .then((res) => res.text())
+      .then((code) => _csound.compileOrc(code));
   }
-  await _csound.compileOrc(orcCache[url]);
+  await orcCache[url];
 }


### PR DESCRIPTION
loadOrc did cache only the orc text but always did a recompilation which results in sound skips for large files. recompilation is not needed, as the file is not expected to change