### PR TITLE
Switch 'operators' from .whatHow to .what.how

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -400,7 +400,7 @@ const generic_params = [
    * @example
    * freq("220 110 440 110").s("superzow").osc()
    * @example
-   * freq("110".mulOut(".5 1.5 .6 [2 3]")).s("superzow").osc()
+   * freq("110".mul.out(".5 1.5 .6 [2 3]")).s("superzow").osc()
    *
    */
   ['f', 'freq', ''],

--- a/packages/core/test/pattern.test.mjs
+++ b/packages/core/test/pattern.test.mjs
@@ -156,32 +156,32 @@ describe('Pattern', () => {
   describe('add()', () => {
     it('can structure In()', () => {
       expect(pure(3).add(pure(4)).query(st(0, 1))[0].value).toBe(7);
-      expect(pure(3).addIn(pure(4)).query(st(0, 1))[0].value).toBe(7);
+      expect(pure(3).add.in(pure(4)).query(st(0, 1))[0].value).toBe(7);
     });
     it('can structure Out()', () => {
-      sameFirst(sequence(1, 2).addOut(4), sequence(5, 6).struct(true));
+      sameFirst(sequence(1, 2).add.out(4), sequence(5, 6).struct(true));
     });
     it('can Mix() structure', () => {
-      expect(sequence(1, 2).addMix(silence, 5, silence).firstCycle()).toStrictEqual([
+      expect(sequence(1, 2).add.mix(silence, 5, silence).firstCycle()).toStrictEqual([
         new Hap(ts(1 / 3, 1 / 2), ts(1 / 3, 1 / 2), 6),
         new Hap(ts(1 / 2, 2 / 3), ts(1 / 2, 2 / 3), 7),
       ]);
     });
     it('can Trig() structure', () => {
       sameFirst(
-        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).addTrig(20, 30).early(2),
+        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).add.trig(20, 30).early(2),
         sequence(26, 27, 36, 37),
       );
     });
     it('can Trigzero() structure', () => {
       sameFirst(
-        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).addTrigzero(20, 30).early(2),
+        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).add.trigzero(20, 30).early(2),
         sequence(21, 22, 31, 32),
       );
     });
     it('can Squeeze() structure', () => {
       sameFirst(
-        sequence(1, [2, 3]).addSqueeze(sequence(10, 20, 30)),
+        sequence(1, [2, 3]).add.squeeze(sequence(10, 20, 30)),
         sequence(
           [11, 21, 31],
           [
@@ -193,7 +193,7 @@ describe('Pattern', () => {
     });
     it('can SqueezeOut() structure', () => {
       sameFirst(
-        sequence(1, [2, 3]).addSqueezeOut(10, 20, 30),
+        sequence(1, [2, 3]).add.squeezeout(10, 20, 30),
         sequence([11, [12, 13]], [21, [22, 23]], [31, [32, 33]]),
       );
     });
@@ -204,32 +204,32 @@ describe('Pattern', () => {
   describe('keep()', () => {
     it('can structure In()', () => {
       expect(pure(3).keep(pure(4)).query(st(0, 1))[0].value).toBe(3);
-      expect(pure(3).keepIn(pure(4)).query(st(0, 1))[0].value).toBe(3);
+      expect(pure(3).keep.in(pure(4)).query(st(0, 1))[0].value).toBe(3);
     });
     it('can structure Out()', () => {
-      sameFirst(sequence(1, 2).keepOut(4), sequence(1, 2).struct(true));
+      sameFirst(sequence(1, 2).keep.out(4), sequence(1, 2).struct(true));
     });
     it('can Mix() structure', () => {
-      expect(sequence(1, 2).keepMix(silence, 5, silence).firstCycle()).toStrictEqual([
+      expect(sequence(1, 2).keep.mix(silence, 5, silence).firstCycle()).toStrictEqual([
         new Hap(ts(1 / 3, 1 / 2), ts(1 / 3, 1 / 2), 1),
         new Hap(ts(1 / 2, 2 / 3), ts(1 / 2, 2 / 3), 2),
       ]);
     });
     it('can Trig() structure', () => {
       sameFirst(
-        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).keepTrig(20, 30).early(2),
+        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).keep.trig(20, 30).early(2),
         sequence(6, 7, 6, 7),
       );
     });
     it('can Trigzero() structure', () => {
       sameFirst(
-        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).keepTrigzero(20, 30).early(2),
+        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).keep.trigzero(20, 30).early(2),
         sequence(1, 2, 1, 2),
       );
     });
     it('can Squeeze() structure', () => {
       sameFirst(
-        sequence(1, [2, 3]).keepSqueeze(sequence(10, 20, 30)),
+        sequence(1, [2, 3]).keep.squeeze(sequence(10, 20, 30)),
         sequence(
           [1, 1, 1],
           [
@@ -240,38 +240,38 @@ describe('Pattern', () => {
       );
     });
     it('can SqueezeOut() structure', () => {
-      sameFirst(sequence(1, [2, 3]).keepSqueezeOut(10, 20, 30), sequence([1, [2, 3]], [1, [2, 3]], [1, [2, 3]]));
+      sameFirst(sequence(1, [2, 3]).keep.squeezeout(10, 20, 30), sequence([1, [2, 3]], [1, [2, 3]], [1, [2, 3]]));
     });
   });
   describe('keepif()', () => {
     it('can structure In()', () => {
       sameFirst(sequence(3, 4).keepif(true, false), sequence(3, silence));
-      sameFirst(sequence(3, 4).keepifIn(true, false), sequence(3, silence));
+      sameFirst(sequence(3, 4).keepif.in(true, false), sequence(3, silence));
     });
     it('can structure Out()', () => {
-      sameFirst(pure(1).keepifOut(true, false), sequence(1, silence));
+      sameFirst(pure(1).keepif.out(true, false), sequence(1, silence));
     });
     it('can Mix() structure', () => {
-      expect(sequence(1, 2).keepifMix(false, true, false).firstCycle()).toStrictEqual([
+      expect(sequence(1, 2).keepif.mix(false, true, false).firstCycle()).toStrictEqual([
         new Hap(ts(1 / 3, 1 / 2), ts(1 / 3, 1 / 2), 1),
         new Hap(ts(1 / 2, 2 / 3), ts(1 / 2, 2 / 3), 2),
       ]);
     });
     it('can Trig() structure', () => {
       sameFirst(
-        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).keepifTrig(false, true).early(2),
+        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).keepif.trig(false, true).early(2),
         sequence(silence, silence, 6, 7),
       );
     });
     it('can Trigzero() structure', () => {
       sameFirst(
-        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).keepifTrigzero(false, true).early(2),
+        slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10).keepif.trigzero(false, true).early(2),
         sequence(silence, silence, 1, 2),
       );
     });
     it('can Squeeze() structure', () => {
       sameFirst(
-        sequence(1, [2, 3]).keepifSqueeze(sequence(true, true, false)),
+        sequence(1, [2, 3]).keepif.squeeze(sequence(true, true, false)),
         sequence(
           [1, 1, silence],
           [
@@ -282,7 +282,7 @@ describe('Pattern', () => {
       );
     });
     it('can SqueezeOut() structure', () => {
-      sameFirst(sequence(1, [2, 3]).keepifSqueezeOut(true, true, false), sequence([1, [2, 3]], [1, [2, 3]], silence));
+      sameFirst(sequence(1, [2, 3]).keepif.squeezeout(true, true, false), sequence([1, [2, 3]], [1, [2, 3]], silence));
     });
   });
   describe('sub()', () => {
@@ -322,13 +322,13 @@ describe('Pattern', () => {
     });
     describe('setOut()', () => {
       it('Can set things with structure from second pattern', () => {
-        sameFirst(sequence(1, 2).setOut(4), pure(4).mask(true, true));
+        sameFirst(sequence(1, 2).set.out(4), pure(4).mask(true, true));
       });
     });
     describe('setSqueeze()', () => {
       it('Can squeeze one pattern inside the haps of another', () => {
         sameFirst(
-          sequence(1, [2, 3]).setSqueeze(sequence('a', 'b', 'c')),
+          sequence(1, [2, 3]).set.squeeze(sequence('a', 'b', 'c')),
           sequence(
             ['a', 'b', 'c'],
             [
@@ -338,7 +338,7 @@ describe('Pattern', () => {
           ),
         );
         sameFirst(
-          sequence(1, [2, 3]).setSqueeze('a', 'b', 'c'),
+          sequence(1, [2, 3]).set.squeeze('a', 'b', 'c'),
           sequence(
             ['a', 'b', 'c'],
             [

--- a/packages/core/test/util.test.mjs
+++ b/packages/core/test/util.test.mjs
@@ -10,7 +10,7 @@ import {
   tokenizeNote,
   toMidi,
   fromMidi,
-  mod,
+  _mod,
   compose,
   getFrequency,
   getPlayableNoteValue,
@@ -118,22 +118,22 @@ describe('getFrequency', () => {
   });
 });
 
-describe('mod', () => {
+describe('_mod', () => {
   it('should work like regular modulo with positive numbers', () => {
-    expect(mod(0, 3)).toEqual(0);
-    expect(mod(1, 3)).toEqual(1);
-    expect(mod(2, 3)).toEqual(2);
-    expect(mod(3, 3)).toEqual(0);
-    expect(mod(4, 3)).toEqual(1);
-    expect(mod(4, 2)).toEqual(0);
+    expect(_mod(0, 3)).toEqual(0);
+    expect(_mod(1, 3)).toEqual(1);
+    expect(_mod(2, 3)).toEqual(2);
+    expect(_mod(3, 3)).toEqual(0);
+    expect(_mod(4, 3)).toEqual(1);
+    expect(_mod(4, 2)).toEqual(0);
   });
   it('should work with negative numbers', () => {
-    expect(mod(-1, 3)).toEqual(2);
-    expect(mod(-2, 3)).toEqual(1);
-    expect(mod(-3, 3)).toEqual(0);
-    expect(mod(-4, 3)).toEqual(2);
-    expect(mod(-5, 3)).toEqual(1);
-    expect(mod(-3, 2)).toEqual(1);
+    expect(_mod(-1, 3)).toEqual(2);
+    expect(_mod(-2, 3)).toEqual(1);
+    expect(_mod(-3, 3)).toEqual(0);
+    expect(_mod(-4, 3)).toEqual(2);
+    expect(_mod(-5, 3)).toEqual(1);
+    expect(_mod(-3, 2)).toEqual(1);
   });
 });
 

--- a/packages/core/util.mjs
+++ b/packages/core/util.mjs
@@ -50,9 +50,8 @@ export const midi2note = (n) => {
   return pc + oct;
 };
 
-// modulo that works with negative numbers e.g. mod(-1, 3) = 2
-// const mod = (n: number, m: number): number => (n < 0 ? mod(n + m, m) : n % m);
-export const mod = (n, m) => ((n % m) + m) % m;
+// modulo that works with negative numbers e.g. _mod(-1, 3) = 2. Works on numbers (rather than patterns of numbers, as @mod@ from pattern.mjs does)
+export const _mod = (n, m) => ((n % m) + m) % m;
 
 export const getPlayableNoteValue = (hap) => {
   let { value, context } = hap;

--- a/packages/tonal/tonal.mjs
+++ b/packages/tonal/tonal.mjs
@@ -5,7 +5,7 @@ This program is free software: you can redistribute it and/or modify it under th
 */
 
 import { Note, Interval, Scale } from '@tonaljs/tonal';
-import { Pattern, mod } from '@strudel.cycles/core';
+import { Pattern, _mod } from '@strudel.cycles/core';
 
 // transpose note inside scale by offset steps
 // function scaleOffset(scale: string, offset: number, note: string) {
@@ -29,7 +29,7 @@ function scaleOffset(scale, offset, note) {
   // TODO: find way to do this smarter
   while (Math.abs(i - noteIndex) < Math.abs(offset)) {
     i += direction;
-    const index = mod(i, notes.length);
+    const index = _mod(i, notes.length);
     if (direction < 0 && n[0] === 'C') {
       o += direction;
     }


### PR DESCRIPTION
Makes sure there are toplevel curried functions for all of them.
Renames util.mod to util._mod, to make room for toplevel 'operator' of that name.