### PR TITLE
object support for .scale

### DIFF
--- a/packages/tonal/test/tonal.test.mjs
+++ b/packages/tonal/test/tonal.test.mjs
@@ -7,11 +7,27 @@ This program is free software: you can redistribute it and/or modify it under th
 // import { strict as assert } from 'assert';
 
 import '../tonal.mjs'; // need to import this to add prototypes
-import { pure } from '@strudel.cycles/core';
+import { pure, controls, seq } from '@strudel.cycles/core';
 import { describe, it, expect } from 'vitest';
+const { n } = controls;
 
 describe('tonal', () => {
   it('Should run tonal functions ', () => {
     expect(pure('c3').scale('C major').scaleTranspose(1).firstCycleValues).toEqual(['D3']);
+  });
+  it('scale with plain values', () => {
+    expect(
+      seq(0, 1, 2)
+        .scale('C major')
+        .note()
+        .firstCycleValues.map((h) => h.note),
+    ).toEqual(['C3', 'D3', 'E3']);
+  });
+  it('scale with n values', () => {
+    expect(
+      n(0, 1, 2)
+        .scale('C major')
+        .firstCycleValues.map((h) => h.note),
+    ).toEqual(['C3', 'D3', 'E3']);
   });
 });

--- a/packages/tonal/tonal.mjs
+++ b/packages/tonal/tonal.mjs
@@ -141,13 +141,14 @@ export const scaleTranspose = register('scaleTranspose', function (offset /* : n
 
 export const scale = register('scale', function (scale /* : string */, pat) {
   return pat.withHap((hap) => {
-    let note = hap.value;
+    const isObject = typeof hap.value === 'object';
+    let note = isObject ? hap.value.n : hap.value;
     const asNumber = Number(note);
     if (!isNaN(asNumber)) {
       let [tonic, scaleName] = Scale.tokenize(scale);
       const { pc, oct = 3 } = Note.get(tonic);
       note = scaleOffset(pc + ' ' + scaleName, asNumber, pc + oct);
     }
-    return hap.withValue(() => note).setContext({ ...hap.context, scale });
+    return hap.withValue(() => (isObject ? { ...hap.value, note } : note)).setContext({ ...hap.context, scale });
   });
 });

--- a/repl/src/tunes.mjs
+++ b/repl/src/tunes.mjs
@@ -310,22 +310,43 @@ export const goodTimes = `// licensed with CC BY-NC-SA 4.0 https://creativecommo
 const scale = cat('C3 dorian','Bb2 major').slow(4);
 stack(
   "2*4".add(12).scale(scale)
-  .off(1/8,x=>x.scaleTranspose("2")).fast(2)
+  .off(1/8, scaleTranspose("2")).fast(2)
   .scaleTranspose("<0 1 2 1>").hush(),
   "<0 1 2 3>(3,8,2)"
   .scale(scale)
-  .off(1/4,x=>x.scaleTranspose("2,4")),
+  .off(1/4, scaleTranspose("2,4")),
   "<0 4>(5,8)".scale(scale).transpose(-12)
 )
   .velocity(".6 .7".fast(4))
   .legato("2")
+  .scaleTranspose("<0>".slow(4))
+  .transpose(5)
+  .note().piano()
+  .velocity(.8)
+  .slow(2)
+  .pianoroll({maxMidi:100,minMidi:20})`;
+
+/* // new style notation:
+export const goodTimes = `// licensed with CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// by Felix Roos
+const scale = cat('C3 dorian','Bb2 major').slow(4);
+stack(
+  n("2*4").add(12)
+  .off(1/8, add("2")).fast(2)
+  .add("<0 1 2 1>").hush(),
+  n("<0 1 2 3>(3,8,2)")
+  .off(1/4, add("2,4")),
+  n("<0 4>(5,8)").sub(7)
+)
   .scale(scale)
-.scaleTranspose("<0>".slow(4))
-.transpose(5)
-.note().piano()
-.velocity(.8)
-.slow(2)
-.pianoroll({maxMidi:100,minMidi:20})`;
+  .gain(".6 .7".fast(4))
+  .legato(2)
+  .add(note(5))
+  .piano()
+  .mul(gain(.8))
+  .slow(2)
+  .pianoroll({maxMidi:100,minMidi:20})`;
+*/
 
 export const echoPiano = `// licensed with CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
 // by Felix Roos


### PR DESCRIPTION
.scale can now be used on object values. if a value is an object, scale will use the n value. example:

```js
n("0 1 2").scale('D minor')
```

before (still works), this was needed:

```js
"0 1 2".scale('D minor').note()
// or
note("0 1 2".scale('D minor'))
```