### PR TITLE
fix: copy share link to clipboard was broken for some browers

### DIFF
--- a/repl/src/App.jsx
+++ b/repl/src/App.jsx
@@ -219,7 +219,7 @@ function App() {
       setLastShared(activeCode || code);
       const shareUrl = window.location.origin + '?' + hash;
       // copy shareUrl to clipboard
-      navigator.clipboard.writeText(shareUrl);
+      await navigator.clipboard.writeText(shareUrl);
       const message = `Link copied to clipboard: ${shareUrl}`;
       alert(message);
       // alert(message);


### PR DESCRIPTION
hopefully fixes it.. cannot test because it worked on my machine 