### PR TITLE
animation options

### DIFF
--- a/packages/core/animate.mjs
+++ b/packages/core/animate.mjs
@@ -7,7 +7,7 @@ Pattern.prototype.animate = function ({ callback, sync = false, smear = 0.5 } = 
   window.frame && cancelAnimationFrame(window.frame);
   const ctx = getDrawContext();
   const { clientWidth: ww, clientHeight: wh } = ctx.canvas;
-  let smearPart = Number((1 - smear) * 100).toFixed(0);
+  let smearPart = smear === 0 ? '99' : Number((1 - smear) * 100).toFixed(0);
   smearPart = smearPart.length === 1 ? `0${smearPart}` : smearPart;
   clearColor = `#200010${smearPart}`;
   const render = (t) => {

--- a/packages/core/animate.mjs
+++ b/packages/core/animate.mjs
@@ -1,17 +1,18 @@
 import { controls, Pattern, getDrawContext, silence, scheduler } from './index.mjs';
 const { createParams } = controls;
 
-let clearColor = '#20001010';
-let currentSmear = 0.5;
-export let syncAnimationWithScheduler = true;
+let clearColor = '#22222210';
 
-Pattern.prototype.animate = function (callback) {
+Pattern.prototype.animate = function ({ callback, sync = false, smear = 0.5 } = {}) {
   window.frame && cancelAnimationFrame(window.frame);
   const ctx = getDrawContext();
   const { clientWidth: ww, clientHeight: wh } = ctx.canvas;
+  let smearPart = Number((1 - smear) * 100).toFixed(0);
+  smearPart = smearPart.length === 1 ? `0${smearPart}` : smearPart;
+  clearColor = `#200010${smearPart}`;
   const render = (t) => {
     let frame;
-    if (syncAnimationWithScheduler) {
+    if (sync) {
       t = scheduler.now();
       frame = this.queryArc(t, t);
     } else {
@@ -21,13 +22,7 @@ Pattern.prototype.animate = function (callback) {
     ctx.fillStyle = clearColor;
     ctx.fillRect(0, 0, ww, wh);
     frame.forEach((f) => {
-      let { x, y, w, h, s, r, a = 0, fill = 'darkseagreen', smear } = f.value;
-      if (smear && smear !== currentSmear) {
-        currentSmear = smear;
-        let smearPart = Number((1 - smear) * 100).toFixed(0);
-        smearPart = smearPart.length === 1 ? `0${smearPart}` : smearPart;
-        clearColor = `#200010${smearPart}`;
-      }
+      let { x, y, w, h, s, r, a = 0, fill = 'darkseagreen' } = f.value;
       w *= ww;
       h *= wh;
       if (r !== undefined && a !== undefined) {


### PR DESCRIPTION
- do not sync by default

using the audio context clock for visual rendering seems to bring a lot of jitter.. it now has to be turned on explicitly:

`.animate({sync: 1})`