### PR TITLE
Fixed duplicated directory separators in fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2949,10 +2949,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bjork": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "dev": true,
@@ -12236,7 +12232,6 @@
       "version": "0.5.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "bjork": "^0.0.1",
         "fraction.js": "^4.2.0"
       }
     },
@@ -12294,11 +12289,6 @@
       "name": "@strudel.cycles/mini",
       "version": "0.5.0",
       "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "@strudel.cycles/core": "^0.5.0",
-        "@strudel.cycles/eval": "^0.5.0",
-        "@strudel.cycles/tone": "^0.5.0"
-      },
       "devDependencies": {
         "peggy": "^2.0.1"
       }
@@ -12429,7 +12419,6 @@
       "version": "0.5.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@strudel.cycles/core": "^0.5.0",
         "@tonaljs/tonal": "^4.7.2",
         "chord-voicings": "^0.0.1",
         "webmidi": "^3.0.21"
@@ -12462,7 +12451,6 @@
       "version": "0.5.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@strudel.cycles/core": "^0.5.0",
         "acorn": "^8.8.1",
         "escodegen": "^2.0.0",
         "estree-walker": "^3.0.1"
@@ -12491,7 +12479,6 @@
       "version": "0.5.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@strudel.cycles/core": "^0.5.0",
         "WebDirt": "github:dktr0/WebDirt"
       }
     },
@@ -13997,7 +13984,6 @@
     "@strudel.cycles/core": {
       "version": "file:packages/core",
       "requires": {
-        "bjork": "^0.0.1",
         "fraction.js": "^4.2.0"
       }
     },
@@ -14042,9 +14028,6 @@
     "@strudel.cycles/mini": {
       "version": "file:packages/mini",
       "requires": {
-        "@strudel.cycles/core": "^0.5.0",
-        "@strudel.cycles/eval": "^0.5.0",
-        "@strudel.cycles/tone": "^0.5.0",
         "peggy": "^2.0.1"
       }
     },
@@ -14132,7 +14115,6 @@
     "@strudel.cycles/tonal": {
       "version": "file:packages/tonal",
       "requires": {
-        "@strudel.cycles/core": "^0.5.0",
         "@tonaljs/tonal": "^4.7.2",
         "chord-voicings": "^0.0.1",
         "webmidi": "^3.0.21"
@@ -14157,7 +14139,6 @@
     "@strudel.cycles/transpiler": {
       "version": "file:packages/transpiler",
       "requires": {
-        "@strudel.cycles/core": "^0.5.0",
         "acorn": "^8.8.1",
         "escodegen": "^2.0.0",
         "estree-walker": "^3.0.1"
@@ -14177,7 +14158,6 @@
     "@strudel.cycles/webdirt": {
       "version": "file:packages/webdirt",
       "requires": {
-        "@strudel.cycles/core": "^0.5.0",
         "WebDirt": "github:dktr0/WebDirt"
       }
     },
@@ -14744,9 +14724,6 @@
     "binary-extensions": {
       "version": "2.2.0",
       "dev": true
-    },
-    "bjork": {
-      "version": "0.0.1"
     },
     "bl": {
       "version": "4.1.0",

--- a/packages/webaudio/sampler.mjs
+++ b/packages/webaudio/sampler.mjs
@@ -126,7 +126,7 @@ export const samples = async (sampleMap, baseUrl = sampleMap._base || '') => {
     if (sampleMap.startsWith('github:')) {
       const [_, path] = sampleMap.split('github:');
       sampleMap = `https://raw.githubusercontent.com/${path}/strudel.json`;
-      // undici fails if a pathspace has more than one directory separator.
+      // undici fails if a patchspec has a duplicated directory separator.
       sampleMap = sampleMap.replace("//strudel.json", "/strudel.json");
     }
     if (typeof fetch !== 'function') {

--- a/packages/webaudio/sampler.mjs
+++ b/packages/webaudio/sampler.mjs
@@ -126,6 +126,8 @@ export const samples = async (sampleMap, baseUrl = sampleMap._base || '') => {
     if (sampleMap.startsWith('github:')) {
       const [_, path] = sampleMap.split('github:');
       sampleMap = `https://raw.githubusercontent.com/${path}/strudel.json`;
+      // undici fails if a pathspace has more than one directory separator.
+      sampleMap = sampleMap.replace("//strudel.json", "/strudel.json");
     }
     if (typeof fetch !== 'function') {
       // not a browser


### PR DESCRIPTION
On macOS Ventura 13.1 `npm run build` fails with:
```
  +- /img/example-festivalOfFingers3.png (+0.88s)
TypeError: fetch failed
    at Object.fetch (node:internal/deps/undici/undici:14062:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async eval (eval at safeEval (file:///Users/michaelgogins/gogins-strudel/website/dist/entry.mjs?time=1673462833107:6342:10), <anonymous>:3:34)
    at async evaluate$1 (file:///Users/michaelgogins/gogins-strudel/website/dist/entry.mjs?time=1673462833107:6354:19)
    at async Module.get (file:///Users/michaelgogins/gogins-strudel/website/dist/entry.mjs?time=1673462833107:31062:23)
    at async call (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/endpoint/index.js:70:20)
    at async generatePath (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/generate.js:271:20)
    at async generatePage (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/generate.js:110:5)
    at async generatePages (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/generate.js:69:7)
    at async staticBuild (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/static-build.js:68:7)
    at async AstroBuilder.build (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/index.js:86:5)
    at async AstroBuilder.run (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/index.js:127:7)
    at async build (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/index.js:21:3)
    at async runCommand (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/cli/index.js:150:14)
    at async cli (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/cli/index.js:168:5) {
  cause: TypeError: Cannot read properties of undefined (reading 'reason')
      at makeAppropriateNetworkError (node:internal/deps/undici/undici:6736:171)
      at schemeFetch (node:internal/deps/undici/undici:13492:16)
      at node:internal/deps/undici/undici:13422:26
      at mainFetch (node:internal/deps/undici/undici:13439:11)
      at httpRedirectFetch (node:internal/deps/undici/undici:13692:14)
      at httpFetch (node:internal/deps/undici/undici:13638:28)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async schemeFetch (node:internal/deps/undici/undici:13546:18)
      at async node:internal/deps/undici/undici:13422:20
      at async mainFetch (node:internal/deps/undici/undici:13418:20)
}
 error   error loading "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master//strudel.json"
  File:
    /Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/endpoint/index.js:70:20
  Code:
    69 |   });
    > 70 |   const response = await renderEndpoint(mod, context, env.ssr);
         |                    ^
      71 |   if (response instanceof Response) {
      72 |     attachToResponse(response, context.cookies);
      73 |     return {
  Stacktrace:
Error: error loading "https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master//strudel.json"
    at file:///Users/michaelgogins/gogins-strudel/website/dist/entry.mjs:7486:15
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async eval (eval at safeEval (file:///Users/michaelgogins/gogins-strudel/website/dist/entry.mjs?time=1673462833107:6342:10), <anonymous>:3:34)
    at async evaluate$1 (file:///Users/michaelgogins/gogins-strudel/website/dist/entry.mjs?time=1673462833107:6354:19)
    at async Module.get (file:///Users/michaelgogins/gogins-strudel/website/dist/entry.mjs?time=1673462833107:31062:23)
    at async call (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/endpoint/index.js:70:20)
    at async generatePath (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/generate.js:271:20)
    at async generatePage (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/generate.js:110:5)
    at async generatePages (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/generate.js:69:7)
    at async staticBuild (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/static-build.js:68:7)
    at async AstroBuilder.build (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/index.js:86:5)
    at async AstroBuilder.run (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/index.js:127:7)
    at async build (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/core/build/index.js:21:3)
    at async runCommand (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/cli/index.js:150:14)
    at async cli (file:///Users/michaelgogins/gogins-strudel/website/node_modules/astro/dist/cli/index.js:168:5)
```
This is apparently caused by the presence of `//` instead of `/` as a directory separator in a fetch URL. I added code in `webaudio/sampler.mjs` to remove the offending `//` and replace it with `/`, and `npm run build` now succeeds.
