### PR TITLE
add caching strategy for missing file types + cache all samples loaded from github

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -31,6 +31,27 @@ export default defineConfig({
     mdx(options),
     tailwind(),
     AstroPWA({
+      registerType: 'autoUpdate',
+      injectRegister: 'auto',
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,json,wav,mp3,ogg}'],
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/raw\.githubusercontent\.com\/.*/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'github-files',
+              expiration: {
+                maxEntries: 200,
+                maxAgeSeconds: 60 * 60 * 24 * 30, // <== 14 days
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+        ],
+      },
       devOptions: {
         enabled: true,
       },


### PR DESCRIPTION
this is a smarter approach than https://github.com/tidalcycles/strudel/pull/415 using the service worker to cache samples instead of a manual client side approach

now, all samples loaded from strudel.tidalcycles.org + from a github domain will be cached