### PR TITLE
add more offline caching

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -37,12 +37,18 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg,json,wav,mp3,ogg}'],
         runtimeCaching: [
           {
-            urlPattern: /^https:\/\/raw\.githubusercontent\.com\/.*/i,
+            urlPattern: ({ url }) => {
+              [
+                /^https:\/\/raw\.githubusercontent\.com\/.*/i,
+                /^https:\/\/freesound\.org\/.*/i,
+                /^https:\/\/shabda\.ndre\.gr\/.*/i,
+              ].some((regex) => regex.test(url));
+            },
             handler: 'CacheFirst',
             options: {
               cacheName: 'github-files',
               expiration: {
-                maxEntries: 200,
+                maxEntries: 5000,
                 maxAgeSeconds: 60 * 60 * 24 * 30, // <== 14 days
               },
               cacheableResponse: {
@@ -53,7 +59,7 @@ export default defineConfig({
         ],
       },
       devOptions: {
-        enabled: true,
+        enabled: false,
       },
       manifest: {
         includeAssets: ['favicon.ico', 'icons/apple-icon-180.png', 'favicon.svg'],

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -37,16 +37,15 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg,json,wav,mp3,ogg}'],
         runtimeCaching: [
           {
-            urlPattern: ({ url }) => {
+            urlPattern: ({ url }) =>
               [
                 /^https:\/\/raw\.githubusercontent\.com\/.*/i,
                 /^https:\/\/freesound\.org\/.*/i,
                 /^https:\/\/shabda\.ndre\.gr\/.*/i,
-              ].some((regex) => regex.test(url));
-            },
+              ].some((regex) => regex.test(url)),
             handler: 'CacheFirst',
             options: {
-              cacheName: 'github-files',
+              cacheName: 'external-samples',
               expiration: {
                 maxEntries: 5000,
                 maxAgeSeconds: 60 * 60 * 24 * 30, // <== 14 days


### PR DESCRIPTION
fixes https://github.com/tidalcycles/strudel/issues/420
also disabled the service worker in dev mode, because it sometimes throws annoying errors.
if the application should run offline locally, one can still run `pnpm build && pnpm preview`