### PR TITLE
WAM2 output

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -15,3 +15,4 @@ export * from './packages/transpiler/index.mjs';
 export * from './packages/webaudio/index.mjs';
 export * from './packages/webdirt/index.mjs';
 export * from './packages/xen/index.mjs';
+export * from './packages/wam/index.mjs';

--- a/packages/wam/index.mjs
+++ b/packages/wam/index.mjs
@@ -6,7 +6,8 @@ import {initializeWamHost} from '@webaudiomodules/sdk'
 let wams = {};
 
 // this is a map of all WebAudioModule instances (possibly more than one per WAM)
-let instances = {};
+let wamInstances = {};
+export const getWamInstances = () => wamInstances;
 
 // has the WAM host been initialized?
 let initialized = false
@@ -20,8 +21,8 @@ export const loadWAM = async function (name, url, what) {
         initialized = true
     }
 
-    if (!!instances[name]) {
-        return instances[name]
+    if (!!wamInstances[name]) {
+        return wamInstances[name]
     }
     
     if (!wams[url]) {
@@ -38,7 +39,7 @@ export const loadWAM = async function (name, url, what) {
 
     instance.audioNode.connect(getAudioContext().destination);
 
-    instances[name] = instance
+    wamInstances[name] = instance
 
     return instance
 }
@@ -48,7 +49,7 @@ export const loadWam = loadWAM;
 
 export const wam = register('wam', function (name, pat) {
     return pat.onTrigger((time, hap) => {
-        let i = instances[name]
+        let i = wamInstances[name]
 
         if (!i) {
             return
@@ -72,24 +73,20 @@ export const wam = register('wam', function (name, pat) {
     });
   });
 
-export const param = register('param', function(wam, param, value, pat) {
-    return pat.onTrigger((time, hap) => {        
-        let i = instances[wam]
-
-        if (!i) {
-            return
-        }
-
-        debugger
-        
-        i.audioNode.scheduleEvents({
-            time: time,
-            type: "wam-automation",
-            data: {
-                id: param,
-                normalized: false,
-                value: value
-            },
-        })
-    })
-})
+export const param = register('param', function (wam, param, pat) {
+    return pat.onTrigger((time, hap) => {
+      let i = wamInstances[wam];
+      if (!i) {
+        return;
+      }
+      i.audioNode.scheduleEvents({
+        time: time,
+        type: 'wam-automation',
+        data: {
+          id: param,
+          normalized: false,
+          value: hap.value,
+        },
+      });
+    }, false);
+  });

--- a/packages/wam/index.mjs
+++ b/packages/wam/index.mjs
@@ -1,0 +1,95 @@
+import { register, Pattern, toMidi, valueToMidi  } from '@strudel.cycles/core';
+import { getAudioContext } from '@strudel.cycles/webaudio';
+import {initializeWamHost} from '@webaudiomodules/sdk'
+
+// this is a map of all loaded WebAudioModules
+let wams = {};
+
+// this is a map of all WebAudioModule instances (possibly more than one per WAM)
+let instances = {};
+
+// has the WAM host been initialized?
+let initialized = false
+
+// host groups of WAMs can interact with one another, but not directly across groups
+const hostGroupId = "strudel"
+
+export const loadWAM = async function (name, url, what) {
+    if (!initialized) {
+        await initializeWamHost(getAudioContext(), hostGroupId)
+        initialized = true
+    }
+
+    if (!!instances[name]) {
+        return instances[name]
+    }
+    
+    if (!wams[url]) {
+        const { default: WAM } = await import(
+            /* @vite-ignore */
+            url);
+
+        wams[url] = WAM
+    }
+    
+    const instance = new wams[url](hostGroupId, getAudioContext());
+    
+    await instance.initialize()
+
+    instance.audioNode.connect(getAudioContext().destination);
+
+    instances[name] = instance
+
+    return instance
+}
+
+export const loadwam = loadWAM;
+export const loadWam = loadWAM;
+
+export const wam = register('wam', function (name, pat) {
+    return pat.onTrigger((time, hap) => {
+        let i = instances[name]
+
+        if (!i) {
+            return
+        }
+
+        let note = toMidi(hap.value.note);
+        let velocity = hap.context?.velocity ?? 0.75;
+        let endTime = time + hap.duration.valueOf();
+
+        i.audioNode.scheduleEvents({
+            type: "wam-midi",
+            data: {bytes: [0x90, note, velocity]},
+            time: time,
+        })
+
+        i.audioNode.scheduleEvents({
+            type: "wam-midi",
+            data: {bytes: [0x80, note, 0]},
+            time: endTime
+        })
+    });
+  });
+
+export const param = register('param', function(wam, param, value, pat) {
+    return pat.onTrigger((time, hap) => {        
+        let i = instances[wam]
+
+        if (!i) {
+            return
+        }
+
+        debugger
+        
+        i.audioNode.scheduleEvents({
+            time: time,
+            type: "wam-automation",
+            data: {
+                id: param,
+                normalized: false,
+                value: value
+            },
+        })
+    })
+})

--- a/packages/wam/package.json
+++ b/packages/wam/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@strudel.cycles/wam",
+  "version": "0.1.0",
+  "description": "WAM2 API for strudel",
+  "main": "index.mjs",
+  "type": "module",
+  "publishConfig": {
+    "main": "dist/index.js",
+    "module": "dist/index.mjs"
+  },
+  "scripts": {
+    "build": "vite build",
+    "prepublishOnly": "npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tidalcycles/strudel.git"
+  },
+  "keywords": [
+    "tidalcycles",
+    "strudel",
+    "pattern",
+    "livecoding",
+    "algorave"
+  ],
+  "author": "Tom Burns <tom@burns.ca>",
+  "license": "AGPL-3.0-or-later",
+  "bugs": {
+    "url": "https://github.com/tidalcycles/strudel/issues"
+  },
+  "homepage": "https://github.com/tidalcycles/strudel#readme",
+  "dependencies": {
+    "@strudel.cycles/core": "workspace:*",
+    "@webaudiomodules/sdk": "^0.0.10",
+    "tone": "^14.7.77"
+  },
+  "devDependencies": {
+    "vite": "^3.2.2",
+    "vitest": "^0.25.7"
+  }
+}

--- a/packages/wam/vite.config.js
+++ b/packages/wam/vite.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import { dependencies } from './package.json';
+import { resolve } from 'path';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'index.mjs'),
+      formats: ['es', 'cjs'],
+      fileName: (ext) => ({ es: 'index.mjs', cjs: 'index.js' }[ext]),
+    },
+    rollupOptions: {
+      external: [...Object.keys(dependencies)],
+    },
+    target: 'esnext',
+  },
+});

--- a/website/package.json
+++ b/website/package.json
@@ -31,6 +31,7 @@
     "@strudel.cycles/soundfonts": "workspace:*",
     "@strudel.cycles/tonal": "workspace:*",
     "@strudel.cycles/transpiler": "workspace:*",
+    "@strudel.cycles/wam": "workspace:*",
     "@strudel.cycles/webaudio": "workspace:*",
     "@strudel.cycles/xen": "workspace:*",
     "@supabase/supabase-js": "^1.35.3",

--- a/website/src/repl/Footer.jsx
+++ b/website/src/repl/Footer.jsx
@@ -7,6 +7,7 @@ import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { loadedSamples } from './Repl';
 import { Reference } from './Reference';
 import { themes, themeColors } from './themes.mjs';
+import { getWamInstances } from '@strudel.cycles/wam';
 
 export function Footer({ context }) {
   // const [activeFooter, setActiveFooter] = useState('console');
@@ -77,6 +78,7 @@ export function Footer({ context }) {
           <FooterTab name="console" />
           <FooterTab name="reference" />
           <FooterTab name="theme" />
+          <FooterTab name="wams" />
         </div>
         {activeFooter !== '' && (
           <button onClick={() => setActiveFooter('')} className="text-foreground" aria-label="Close Panel">
@@ -196,6 +198,13 @@ export function Footer({ context }) {
               ))}
             </div>
           )}
+          {activeFooter === 'wams' && (
+            <div className="break-normal w-full px-4 dark:text-white text-stone-900">
+              <span>{Object.keys(getWamInstances()).length} loaded:</span>
+              <select onChange={(e) => showWAM(e)}><option key="--">--</option>{Object.keys(getWamInstances()).map(w => <option key={w}>{w}</option>)}</select>
+              <div id="wam-gui"></div>
+            </div>
+          )}
         </div>
       )}
     </footer>
@@ -225,4 +234,22 @@ function linkify(inputText) {
   replacedText = replacedText.replace(replacePattern3, '<a class="underline" href="mailto:$1">$1</a>');
 
   return replacedText;
+}
+
+const showWAM = async (e) => {
+  const wam = getWamInstances()[e.target.value];
+  const gui = await wam.createGui();
+  const guiDiv = document.getElementById('wam-gui');
+  guiDiv.innerHTML = '';
+  guiDiv.appendChild(gui);
+  
+  const params = await wam.audioNode.getParameterInfo()
+
+  for (let id of Object.keys(params)) {
+    const param = params[id];
+    const input = document.createElement('div');
+    input.innerHTML = `<label>${id}</label>: type ${param.type}, min ${param.minValue}, max ${param.maxValue}`
+    guiDiv.appendChild(input);
+  }
+
 }

--- a/website/src/repl/Repl.jsx
+++ b/website/src/repl/Repl.jsx
@@ -46,6 +46,7 @@ const modules = [
   import('@strudel.cycles/serial'),
   import('@strudel.cycles/soundfonts'),
   import('@strudel.cycles/csound'),
+  import('@strudel.cycles/wam')
 ];
 
 evalScope(


### PR DESCRIPTION
This adds basic WAM2 loading, playing, GUI rendering to Strudel.

Definitely TODO, from my perspective:
- [ ] `.wam('inst').param('xxx', 0.1)` isn't working yet.  When a `param` is chained onto the wam, the instrument gets defaulted back to the default tone instrument and the wam is not played.
- [ ] WAM patch state is not saved in the URL.  We should call `instance.getState()` to pull the entire patch state

Would be nice:
- [ ] WAM GUIs should be cleaned up with `instance.destroyGUI(element)` as some GUIs otherwise hold onto a reference.

Future work:
- integrating into the same webaudio chain as the other instruments, so we can chain strudel effects after a WAM.  To me this would be the sensible point to also add support for inserting WAM audio effects into the effect chain.
- I liked @felixroos ideas mentioned in Discord around WAMs and samples being interchangeable so you could cycle through different options, but I think it's beyond my capabilities with the existing code and we could probably figure it out faster collaboratively.

