### PR TITLE
fix: osc should not return a promise

### DIFF
--- a/packages/osc/osc.mjs
+++ b/packages/osc/osc.mjs
@@ -45,9 +45,9 @@ let startedAt = -1;
  * @memberof Pattern
  * @returns Pattern
  */
-Pattern.prototype.osc = async function () {
-  const osc = await connect();
-  return this.onTrigger((time, hap, currentTime, cps = 1) => {
+Pattern.prototype.osc = function () {
+  return this.onTrigger(async (time, hap, currentTime, cps = 1) => {
+    const osc = await connect();
     const cycle = hap.wholeOrPart().begin.valueOf();
     const delta = hap.duration.valueOf();
     // time should be audio time of onset


### PR DESCRIPTION
as reported by @bwagner , osc did not work when nested in a pattern. when the async stuff happens inside trigger, it works. fixes https://github.com/tidalcycles/strudel/issues/469