### PR TITLE
add gainpre + gainpost for effect sends

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -78,6 +78,8 @@ const generic_params = [
     'gain',
     'a pattern of numbers that specify volume. Values less than 1 make the sound quieter. Values greater than 1 make the sound louder. For the linear equivalent, see @amp@.',
   ],
+  ['f', 'gainpre'],
+  ['f', 'gainpost'],
   /**
    * Like {@link gain}, but linear.
    *

--- a/packages/webaudio/webaudio.mjs
+++ b/packages/webaudio/webaudio.mjs
@@ -219,6 +219,8 @@ export const webaudioOutput = async (hap, deadline, hapDuration) => {
     n = 0,
     note,
     gain = 0.8,
+    gainpost = 1,
+    gainpre = 1,
     // low pass
     lpf,
     cutoff = lpf,
@@ -373,22 +375,25 @@ export const webaudioOutput = async (hap, deadline, hapDuration) => {
   }
 
   // last gain
-  const post = gainNode(1);
-  chain.push(post);
-  post.connect(getDestination());
+  const pre = gainNode(gainpre);
+  chain.push(pre);
 
   // delay
   let delaySend;
   if (delay > 0 && delaytime > 0 && delayfeedback > 0) {
     const delyNode = getDelay(orbit, delaytime, delayfeedback, t);
-    delaySend = effectSend(post, delyNode, delay);
+    delaySend = effectSend(pre, delyNode, delay);
   }
   // reverb
   let reverbSend;
   if (room > 0 && roomsize > 0) {
     const reverbNode = getReverb(orbit, roomsize);
-    reverbSend = effectSend(post, reverbNode, room);
+    reverbSend = effectSend(pre, reverbNode, room);
   }
+
+  const post = gainNode(gainpost);
+  chain.push(post);
+  post.connect(getDestination());
 
   // connect chain elements together
   chain.slice(1).reduce((last, current) => last.connect(current), chain[0]);


### PR DESCRIPTION
to control the gain of the signal before and after effect sends. as discovered by @bwagner , it was not possible to get only the effect output without the original signal ( fully wet ).