### PR TITLE
can now use : as a replacement for space in scales

### DIFF
--- a/packages/tonal/test/tonal.test.mjs
+++ b/packages/tonal/test/tonal.test.mjs
@@ -30,4 +30,11 @@ describe('tonal', () => {
         .firstCycleValues.map((h) => h.note),
     ).toEqual(['C3', 'D3', 'E3']);
   });
+  it('scale with colon', () => {
+    expect(
+      n(0, 1, 2)
+        .scale('C:major')
+        .firstCycleValues.map((h) => h.note),
+    ).toEqual(['C3', 'D3', 'E3']);
+  });
 });

--- a/packages/tonal/tonal.mjs
+++ b/packages/tonal/tonal.mjs
@@ -146,6 +146,7 @@ export const scale = register('scale', function (scale /* : string */, pat) {
     let note = isObject ? hap.value.n : hap.value;
     const asNumber = Number(note);
     if (!isNaN(asNumber)) {
+      scale = scale.replaceAll('_', ' ');
       let [tonic, scaleName] = Scale.tokenize(scale);
       const { pc, oct = 3 } = Note.get(tonic);
       note = scaleOffset(pc + ' ' + scaleName, asNumber, pc + oct);

--- a/packages/tonal/tonal.mjs
+++ b/packages/tonal/tonal.mjs
@@ -146,7 +146,7 @@ export const scale = register('scale', function (scale /* : string */, pat) {
     let note = isObject ? hap.value.n : hap.value;
     const asNumber = Number(note);
     if (!isNaN(asNumber)) {
-      scale = scale.replaceAll('_', ' ');
+      scale = scale.replaceAll(':', ' ');
       let [tonic, scaleName] = Scale.tokenize(scale);
       const { pc, oct = 3 } = Note.get(tonic);
       note = scaleOffset(pc + ' ' + scaleName, asNumber, pc + oct);


### PR DESCRIPTION
Allowing to use scales in mini notation like 

```js
n("0 2 4 6").scale("<C:major@2 C:minor D:dorian>")
``` 