### PR TITLE
Update packages.mdx

### DIFF
--- a/website/src/pages/technical-manual/packages.mdx
+++ b/website/src/pages/technical-manual/packages.mdx
@@ -7,7 +7,7 @@ import { MiniRepl } from '../../docs/MiniRepl';
 
 # Strudel Packages
 
-The [strudel repo](github.com/tidalcycles/strudel) is organized as a monorepo, containing multiple npm packages.
+The [strudel repo](https://github.com/tidalcycles/strudel) is organized as a monorepo, containing multiple npm packages.
 The purpose of the multiple packages is to
 
 - organize the codebase into more modular, encapsulated pieces


### PR DESCRIPTION
Fix typo

I found a broken link. 

Because it omits protocol, page move to wrong page(`https://strudel.tidalcycles.org/github.com/tidalcycles/strudel`)

I add protocol(`https://`) on that link.