### PR TITLE
Fix typo on packages.mdx

### DIFF
--- a/website/src/pages/technical-manual/packages.mdx
+++ b/website/src/pages/technical-manual/packages.mdx
@@ -5,6 +5,7 @@ layout: ../../layouts/MainLayout.astro
 
 import { MiniRepl } from '../../docs/MiniRepl';
 
+
 # Strudel Packages
 
 The [strudel repo](https://github.com/tidalcycles/strudel) is organized as a monorepo, containing multiple npm packages.

--- a/website/src/pages/technical-manual/packages.mdx
+++ b/website/src/pages/technical-manual/packages.mdx
@@ -7,7 +7,7 @@ import { MiniRepl } from '../../docs/MiniRepl';
 
 # Strudel Packages
 
-The [strudel repo](github.com/tidalcycles/strudel) is organized as a monorepo, containing multiple npm packages.
+The [strudel repo](https://github.com/tidalcycles/strudel) is organized as a monorepo, containing multiple npm packages.
 The purpose of the multiple packages is to
 
 - organize the codebase into more modular, encapsulated pieces

--- a/website/src/pages/technical-manual/packages.mdx
+++ b/website/src/pages/technical-manual/packages.mdx
@@ -5,7 +5,6 @@ layout: ../../layouts/MainLayout.astro
 
 import { MiniRepl } from '../../docs/MiniRepl';
 
-
 # Strudel Packages
 
 The [strudel repo](https://github.com/tidalcycles/strudel) is organized as a monorepo, containing multiple npm packages.


### PR DESCRIPTION
I found a broken link. 

Because it omits protocol, page move to wrong page(`https://strudel.tidalcycles.org/github.com/tidalcycles/strudel`)

I add protocol(`https://`) on that link.