### PR TITLE
fix: envelopes in chrome

### DIFF
--- a/packages/webaudio/helpers.mjs
+++ b/packages/webaudio/helpers.mjs
@@ -27,12 +27,13 @@ export const getEnvelope = (attack, decay, sustain, release, velocity, begin) =>
   return {
     node: gainNode,
     stop: (t) => {
-      if (typeof gainNode.gain.cancelAndHoldAtTime === 'function') {
-        gainNode.gain.cancelAndHoldAtTime(t);
-      } else {
-        // firefox: this will glitch when the sustain has not been reached yet at the time of release
-        gainNode.gain.setValueAtTime(sustain * velocity, t);
-      }
+      //if (typeof gainNode.gain.cancelAndHoldAtTime === 'function') {
+      // gainNode.gain.cancelAndHoldAtTime(t); // this seems to release instantly....
+      // see https://discord.com/channels/779427371270275082/937365093082079272/1086053607360712735
+      //} else {
+      // firefox: this will glitch when the sustain has not been reached yet at the time of release
+      gainNode.gain.setValueAtTime(sustain * velocity, t);
+      //}
       gainNode.gain.linearRampToValueAtTime(0, t + release);
     },
   };

--- a/packages/webaudio/synth.mjs
+++ b/packages/webaudio/synth.mjs
@@ -32,9 +32,9 @@ export function registerSynthSounds() {
         };
         return {
           node: o.connect(g).connect(envelope),
-          stop: (t) => {
-            releaseEnvelope(t);
-            stop(t + release);
+          stop: (releaseTime) => {
+            releaseEnvelope(releaseTime);
+            stop(releaseTime + release);
           },
         };
       },


### PR DESCRIPTION
as reported in by @bwagner , chrome envelopes behave differently.. The reason is "cancelAndHoldAtTime" seems to behave differently than I thought. I commented it out for now.. envelopes in webaudio seem to be a bit messed up :-/
Further investigation is needed