### PR TITLE
FIXES: alias pm for polymeter

### DIFF
--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -1127,6 +1127,8 @@ function _composeOp(a, b, func) {
 export const polyrhythm = stack;
 export const pr = stack;
 
+export const pm = polymeter;
+
 // methods that create patterns, which are added to patternified Pattern methods
 // TODO: remove? this is only used in old transpiler (shapeshifter)
 Pattern.prototype.factories = {
@@ -1372,11 +1374,6 @@ export function polymeterSteps(steps, ...args) {
  */
 export function polymeter(...args) {
   return polymeterSteps(0, ...args);
-}
-
-// alias
-export function pm(...args) {
-  return polymeter(...args);
 }
 
 export const mask = curry((a, b) => reify(b).mask(a));

--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -1376,7 +1376,7 @@ export function polymeter(...args) {
 
 // alias
 export function pm(...args) {
-  polymeter(...args);
+  return polymeter(...args);
 }
 
 export const mask = curry((a, b) => reify(b).mask(a));


### PR DESCRIPTION
(return statement was missing)

I was looking at [polymeter](https://strudel.tidalcycles.org/learn/factories#polymeter) and when replacing `polymeter` by `pm` in the MiniRepl, I got error `"Cannot read properties of undefined (reading 'note')".`

FIXES: Issue https://github.com/tidalcycles/strudel/issues/532