### PR TITLE
fix: flatten scale lists

### DIFF
--- a/packages/tonal/tonal.mjs
+++ b/packages/tonal/tonal.mjs
@@ -154,6 +154,7 @@ export const scale = register('scale', function (scale, pat) {
     if (!isNaN(asNumber)) {
       // TODO: worth keeping for supporting ':' in (non-mininotation) strings?
       scale = scale.replaceAll(':', ' ');
+      scale = scale.replaceAll(',', ' ');
       let [tonic, scaleName] = Scale.tokenize(scale);
       const { pc, oct = 3 } = Note.get(tonic);
       note = scaleOffset(pc + ' ' + scaleName, asNumber, pc + oct);

--- a/packages/tonal/tonal.mjs
+++ b/packages/tonal/tonal.mjs
@@ -145,7 +145,7 @@ export const scaleTranspose = register('scaleTranspose', function (offset /* : n
 export const scale = register('scale', function (scale, pat) {
   // Supports ':' list syntax in mininotation
   if (Array.isArray(scale)) {
-    scale = scale.join(' ');
+    scale = scale.flat().join(' ');
   }
   return pat.withHap((hap) => {
     const isObject = typeof hap.value === 'object';
@@ -154,7 +154,6 @@ export const scale = register('scale', function (scale, pat) {
     if (!isNaN(asNumber)) {
       // TODO: worth keeping for supporting ':' in (non-mininotation) strings?
       scale = scale.replaceAll(':', ' ');
-      scale = scale.replaceAll(',', ' ');
       let [tonic, scaleName] = Scale.tokenize(scale);
       const { pc, oct = 3 } = Note.get(tonic);
       note = scaleOffset(pc + ' ' + scaleName, asNumber, pc + oct);


### PR DESCRIPTION
something like this did not work:

```js
"0 2 <4 7>".scale("<C2 C4>:<bebop:major minor:pentatonic>").note()
```

as it produced a nested array. Now, this works... 