### PR TITLE
desktop: play samples from disk

### DIFF
--- a/packages/webaudio/sampler.mjs
+++ b/packages/webaudio/sampler.mjs
@@ -119,6 +119,21 @@ export const processSampleMap = (sampleMap, fn, baseUrl = sampleMap._base || '')
   });
 };
 
+// allows adding a custom url prefix handler
+// for example, it is used by the desktop app to load samples starting with '~/music'
+let resourcePrefixHandlers = {};
+export function registerSamplesPrefix(prefix, resolve) {
+  resourcePrefixHandlers[prefix] = resolve;
+}
+// finds a prefix handler for the given url (if any)
+function getSamplesPrefixHandler(url) {
+  const handler = Object.entries(resourcePrefixHandlers).find(([key]) => url.startsWith(key));
+  if (handler) {
+    return handler[1];
+  }
+  return;
+}
+
 /**
  * Loads a collection of samples to use with `s`
  * @example
@@ -135,6 +150,11 @@ export const processSampleMap = (sampleMap, fn, baseUrl = sampleMap._base || '')
 
 export const samples = async (sampleMap, baseUrl = sampleMap._base || '', options = {}) => {
   if (typeof sampleMap === 'string') {
+    // check if custom prefix handler
+    const handler = getSamplesPrefixHandler(sampleMap);
+    if (handler) {
+      return handler(sampleMap);
+    }
     if (sampleMap.startsWith('github:')) {
       let [_, path] = sampleMap.split('github:');
       path = path.endsWith('/') ? path.slice(0, -1) : path;

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.4.0", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.4.0", features = [] }
+tauri = { version = "1.4.0", features = ["fs-all"] }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
       "all": false,
       "fs": {
         "all": true,
-        "scope": ["$AUDIO/**", "$AUDIO"]
+        "scope": ["$HOME/**", "$HOME", "$HOME/*"]
       }
     },
     "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,8 @@
     "beforeBuildCommand": "npm run build",
     "beforeDevCommand": "npm run dev",
     "devPath": "http://localhost:3000",
-    "distDir": "../website/dist"
+    "distDir": "../website/dist",
+    "withGlobalTauri": true
   },
   "package": {
     "productName": "Strudel",
@@ -12,7 +13,11 @@
   },
   "tauri": {
     "allowlist": {
-      "all": false
+      "all": false,
+      "fs": {
+        "all": true,
+        "scope": ["$AUDIO/**", "$AUDIO"]
+      }
     },
     "bundle": {
       "active": true,

--- a/website/src/repl/FilesTab.jsx
+++ b/website/src/repl/FilesTab.jsx
@@ -1,59 +1,21 @@
 import { Fragment, useEffect } from 'react';
-import { getAudioContext, loadBuffer, processSampleMap } from '@strudel.cycles/webaudio';
 import React, { useMemo, useState } from 'react';
-
-const TAURI = window.__TAURI__;
-const { BaseDirectory, readDir, readBinaryFile, writeTextFile, readTextFile } = TAURI?.fs || {};
-
-async function loadFiles() {
-  return readDir('', { dir: BaseDirectory.Audio, recursive: true });
-}
-
-const walkFileTree = (node, fn) => {
-  if (!Array.isArray(node?.children)) {
-    return;
-  }
-  for (const entry of node.children) {
-    entry.subpath = (node.subpath || []).concat([node.name]);
-    fn(entry, node);
-    if (entry.children) {
-      walkFileTree(entry, fn);
-    }
-  }
-};
-
-const isAudioFile = (filename) => ['wav', 'mp3'].includes(filename.split('.').slice(-1)[0]);
-function uint8ArrayToDataURL(uint8Array) {
-  const blob = new Blob([uint8Array], { type: 'audio/*' });
-  const dataURL = URL.createObjectURL(blob);
-  return dataURL;
-}
-
-const loadCache = {}; // caches local urls to data urls
-async function resolveFileURL(url) {
-  if (loadCache[url]) {
-    return loadCache[url];
-  }
-  loadCache[url] = (async () => {
-    const contents = await readBinaryFile(url, {
-      dir: BaseDirectory.Audio,
-    });
-    return uint8ArrayToDataURL(contents);
-  })();
-  return loadCache[url];
-}
+import { isAudioFile, readDir, dir } from './files.mjs';
 
 export function FilesTab() {
   const [path, setPath] = useState([]);
   useEffect(() => {
     let init = false;
-    loadFiles().then((_tree) => setPath([{ name: 'files', children: _tree, path: BaseDirectory.Audio }]));
+    readDir('', { dir, recursive: true })
+      .then((children) => setPath([{ name: '~/music', children }]))
+      .catch((err) => {
+        console.log('error loadin files', err);
+      });
     return () => {
       init = true;
     };
   }, []);
   const current = useMemo(() => path[path.length - 1], [path]);
-  const strudelJson = useMemo(() => current?.children?.find((e) => e.name === 'strudel.json'), [current]);
   const subpath = useMemo(
     () =>
       path
@@ -63,47 +25,36 @@ export function FilesTab() {
     [path],
   );
   const folders = useMemo(() => current?.children.filter((e) => !!e.children), [current]);
-
-  const files = useMemo(
-    () => current?.children.filter((e) => !e.children && isAudioFile(e.name) /* || e.name === 'strudel.json' */),
-    [current],
-  );
-  const audioFiles = useMemo(() => {
-    let files = [];
-    walkFileTree(current, (entry) => {
-      if (isAudioFile(entry.name)) {
-        files.push(entry);
-      }
-    });
-    return files;
-  }, [current]);
+  const files = useMemo(() => current?.children.filter((e) => !e.children && isAudioFile(e.name)), [current]);
   const select = (e) => setPath((p) => p.concat([e]));
-
   return (
     <div className="px-4 flex flex-col h-full">
-      <div className="flex justify-between">
+      <div className="flex justify-between font-mono pb-1">
         <div>
+          <span>{`samples('`}</span>
           {path?.map((p, i) => {
             if (i < path.length - 1) {
               return (
                 <Fragment key={i}>
                   <span className="cursor-pointer underline" onClick={() => setPath((p) => p.slice(0, i + 1))}>
                     {p.name}
-                  </span>{' '}
-                  /{' '}
+                  </span>
+                  <span>/</span>
                 </Fragment>
               );
             } else {
               return (
-                <span className="underline" key={i}>
-                  {p.name}{' '}
+                <span className="cursor-pointer underline" key={i}>
+                  {p.name}
                 </span>
               );
             }
           })}
+          <span>{`')`}</span>
         </div>
       </div>
       <div className="overflow-auto">
+        {!folders?.length && !files?.length && <span className="text-gray-500">Nothing here</span>}
         {folders?.map((e, i) => (
           <div className="cursor-pointer" key={i} onClick={() => select(e)}>
             {e.name}
@@ -113,74 +64,11 @@ export function FilesTab() {
           <div
             className="text-gray-500 cursor-pointer select-none"
             key={i}
-            onClick={async () => {
-              const url = await resolveFileURL(`${subpath}/${e.name}`);
-              const ac = getAudioContext();
-              const bufferSource = ac.createBufferSource();
-              bufferSource.buffer = await loadBuffer(url, ac);
-              bufferSource.connect(ac.destination);
-              bufferSource.start(ac.currentTime);
-            }}
+            onClick={async () => playFile(`${subpath}/${e.name}`)}
           >
             {e.name}
           </div>
         ))}
-      </div>
-
-      <div className="flex justify-start space-x-2">
-        <button
-          className="bg-background p-2 max-w-[300px] rounded-md hover:opacity-50"
-          onClick={async () => {
-            let samples = {};
-            walkFileTree(current, (entry, parent) => {
-              if (['wav', 'mp3'].includes(entry.name.split('.').slice(-1)[0])) {
-                samples[parent.name] = samples[parent.name] || [];
-                samples[parent.name].push(entry.subpath.slice(1).concat([entry.name]).join('/'));
-              }
-            });
-            const json = JSON.stringify(samples, null, 2);
-            const filepath = subpath + '/strudel.json';
-            console.log('strudel.json', json);
-            await writeTextFile(filepath, json, { dir: BaseDirectory.Audio });
-            console.log('written strudel.json to:', current.path);
-          }}
-        >
-          save strudel.json with {audioFiles.length} files
-        </button>
-        {strudelJson && (
-          <>
-            <button
-              className="bg-background p-2 max-w-[300px] rounded-md hover:opacity-50"
-              onClick={async () => {
-                const contents = await readTextFile(subpath + '/strudel.json', {
-                  dir: BaseDirectory.Audio,
-                });
-                const sampleMap = JSON.parse(contents);
-                processSampleMap(sampleMap, (key, value) => {
-                  registerSound(
-                    key,
-                    (t, hapValue, onended) => onTriggerSample(t, hapValue, onended, value, resolveFileURL),
-                    {
-                      type: 'sample',
-                      samples: value,
-                      fileSystem: true,
-                      tag: 'local',
-                      /* baseUrl,
-                prebake,
-                tag, */
-                    },
-                  );
-                });
-              }}
-            >
-              load existing strudel.json
-            </button>
-            {/* <button className="bg-background p-2 max-w-[300px] rounded-md hover:opacity-50" onClick={async () => {
-            }}>
-              delete existing strudel.json
-            </button> */}
-          </>
-        )}
       </div>
     </div>
   );

--- a/website/src/repl/FilesTab.jsx
+++ b/website/src/repl/FilesTab.jsx
@@ -1,0 +1,187 @@
+import { Fragment, useEffect } from 'react';
+import { getAudioContext, loadBuffer, processSampleMap } from '@strudel.cycles/webaudio';
+import React, { useMemo, useState } from 'react';
+
+const TAURI = window.__TAURI__;
+const { BaseDirectory, readDir, readBinaryFile, writeTextFile, readTextFile } = TAURI?.fs || {};
+
+async function loadFiles() {
+  return readDir('', { dir: BaseDirectory.Audio, recursive: true });
+}
+
+const walkFileTree = (node, fn) => {
+  if (!Array.isArray(node?.children)) {
+    return;
+  }
+  for (const entry of node.children) {
+    entry.subpath = (node.subpath || []).concat([node.name]);
+    fn(entry, node);
+    if (entry.children) {
+      walkFileTree(entry, fn);
+    }
+  }
+};
+
+const isAudioFile = (filename) => ['wav', 'mp3'].includes(filename.split('.').slice(-1)[0]);
+function uint8ArrayToDataURL(uint8Array) {
+  const blob = new Blob([uint8Array], { type: 'audio/*' });
+  const dataURL = URL.createObjectURL(blob);
+  return dataURL;
+}
+
+const loadCache = {}; // caches local urls to data urls
+async function resolveFileURL(url) {
+  if (loadCache[url]) {
+    return loadCache[url];
+  }
+  loadCache[url] = (async () => {
+    const contents = await readBinaryFile(url, {
+      dir: BaseDirectory.Audio,
+    });
+    return uint8ArrayToDataURL(contents);
+  })();
+  return loadCache[url];
+}
+
+export function FilesTab() {
+  const [path, setPath] = useState([]);
+  useEffect(() => {
+    let init = false;
+    loadFiles().then((_tree) => setPath([{ name: 'files', children: _tree, path: BaseDirectory.Audio }]));
+    return () => {
+      init = true;
+    };
+  }, []);
+  const current = useMemo(() => path[path.length - 1], [path]);
+  const strudelJson = useMemo(() => current?.children?.find((e) => e.name === 'strudel.json'), [current]);
+  const subpath = useMemo(
+    () =>
+      path
+        .slice(1)
+        .map((p) => p.name)
+        .join('/'),
+    [path],
+  );
+  const folders = useMemo(() => current?.children.filter((e) => !!e.children), [current]);
+
+  const files = useMemo(
+    () => current?.children.filter((e) => !e.children && isAudioFile(e.name) /* || e.name === 'strudel.json' */),
+    [current],
+  );
+  const audioFiles = useMemo(() => {
+    let files = [];
+    walkFileTree(current, (entry) => {
+      if (isAudioFile(entry.name)) {
+        files.push(entry);
+      }
+    });
+    return files;
+  }, [current]);
+  const select = (e) => setPath((p) => p.concat([e]));
+
+  return (
+    <div className="px-4 flex flex-col h-full">
+      <div className="flex justify-between">
+        <div>
+          {path?.map((p, i) => {
+            if (i < path.length - 1) {
+              return (
+                <Fragment key={i}>
+                  <span className="cursor-pointer underline" onClick={() => setPath((p) => p.slice(0, i + 1))}>
+                    {p.name}
+                  </span>{' '}
+                  /{' '}
+                </Fragment>
+              );
+            } else {
+              return (
+                <span className="underline" key={i}>
+                  {p.name}{' '}
+                </span>
+              );
+            }
+          })}
+        </div>
+      </div>
+      <div className="overflow-auto">
+        {folders?.map((e, i) => (
+          <div className="cursor-pointer" key={i} onClick={() => select(e)}>
+            {e.name}
+          </div>
+        ))}
+        {files?.map((e, i) => (
+          <div
+            className="text-gray-500 cursor-pointer select-none"
+            key={i}
+            onClick={async () => {
+              const url = await resolveFileURL(`${subpath}/${e.name}`);
+              const ac = getAudioContext();
+              const bufferSource = ac.createBufferSource();
+              bufferSource.buffer = await loadBuffer(url, ac);
+              bufferSource.connect(ac.destination);
+              bufferSource.start(ac.currentTime);
+            }}
+          >
+            {e.name}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex justify-start space-x-2">
+        <button
+          className="bg-background p-2 max-w-[300px] rounded-md hover:opacity-50"
+          onClick={async () => {
+            let samples = {};
+            walkFileTree(current, (entry, parent) => {
+              if (['wav', 'mp3'].includes(entry.name.split('.').slice(-1)[0])) {
+                samples[parent.name] = samples[parent.name] || [];
+                samples[parent.name].push(entry.subpath.slice(1).concat([entry.name]).join('/'));
+              }
+            });
+            const json = JSON.stringify(samples, null, 2);
+            const filepath = subpath + '/strudel.json';
+            console.log('strudel.json', json);
+            await writeTextFile(filepath, json, { dir: BaseDirectory.Audio });
+            console.log('written strudel.json to:', current.path);
+          }}
+        >
+          save strudel.json with {audioFiles.length} files
+        </button>
+        {strudelJson && (
+          <>
+            <button
+              className="bg-background p-2 max-w-[300px] rounded-md hover:opacity-50"
+              onClick={async () => {
+                const contents = await readTextFile(subpath + '/strudel.json', {
+                  dir: BaseDirectory.Audio,
+                });
+                const sampleMap = JSON.parse(contents);
+                processSampleMap(sampleMap, (key, value) => {
+                  registerSound(
+                    key,
+                    (t, hapValue, onended) => onTriggerSample(t, hapValue, onended, value, resolveFileURL),
+                    {
+                      type: 'sample',
+                      samples: value,
+                      fileSystem: true,
+                      tag: 'local',
+                      /* baseUrl,
+                prebake,
+                tag, */
+                    },
+                  );
+                });
+              }}
+            >
+              load existing strudel.json
+            </button>
+            {/* <button className="bg-background p-2 max-w-[300px] rounded-md hover:opacity-50" onClick={async () => {
+            }}>
+              delete existing strudel.json
+            </button> */}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/website/src/repl/FilesTab.jsx
+++ b/website/src/repl/FilesTab.jsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect } from 'react';
 import React, { useMemo, useState } from 'react';
-import { isAudioFile, readDir, dir } from './files.mjs';
+import { isAudioFile, readDir, dir, playFile } from './files.mjs';
 
 export function FilesTab() {
   const [path, setPath] = useState([]);

--- a/website/src/repl/Footer.jsx
+++ b/website/src/repl/Footer.jsx
@@ -9,6 +9,9 @@ import { themes } from './themes.mjs';
 import { useSettings, settingsMap, setActiveFooter, defaultSettings } from '../settings.mjs';
 import { getAudioContext, soundMap } from '@strudel.cycles/webaudio';
 import { useStore } from '@nanostores/react';
+import { FilesTab } from './FilesTab';
+
+const TAURI = window.__TAURI__;
 
 export function Footer({ context }) {
   const footerContent = useRef();
@@ -77,6 +80,7 @@ export function Footer({ context }) {
           <FooterTab name="console" />
           <FooterTab name="reference" />
           <FooterTab name="settings" />
+          {TAURI && <FooterTab name="files" />}
         </div>
         {activeFooter !== '' && (
           <button onClick={() => setActiveFooter('')} className="text-foreground" aria-label="Close Panel">
@@ -91,6 +95,7 @@ export function Footer({ context }) {
           {activeFooter === 'sounds' && <SoundsTab />}
           {activeFooter === 'reference' && <Reference />}
           {activeFooter === 'settings' && <SettingsTab scheduler={context.scheduler} />}
+          {activeFooter === 'files' && <FilesTab />}
         </div>
       )}
     </footer>

--- a/website/src/repl/files.mjs
+++ b/website/src/repl/files.mjs
@@ -1,0 +1,104 @@
+import {
+  processSampleMap,
+  registerSamplesPrefix,
+  registerSound,
+  onTriggerSample,
+  getAudioContext,
+  loadBuffer,
+} from '@strudel.cycles/webaudio';
+
+const TAURI = window.__TAURI__;
+export const { BaseDirectory, readDir, readBinaryFile, writeTextFile, readTextFile, exists } = TAURI?.fs || {};
+
+export const dir = BaseDirectory?.Audio; // https://tauri.app/v1/api/js/path#audiodir
+const prefix = '~/music/';
+
+async function hasStrudelJson(subpath) {
+  return exists(subpath + '/strudel.json', { dir });
+}
+
+async function loadStrudelJson(subpath) {
+  const contents = await readTextFile(subpath + '/strudel.json', { dir });
+  const sampleMap = JSON.parse(contents);
+  processSampleMap(sampleMap, (key, value) => {
+    registerSound(key, (t, hapValue, onended) => onTriggerSample(t, hapValue, onended, value, fileResolver(subpath)), {
+      type: 'sample',
+      samples: value,
+      fileSystem: true,
+      tag: 'local',
+    });
+  });
+}
+
+async function writeStrudelJson(subpath) {
+  const children = await readDir(subpath, { dir, recursive: true });
+  const name = subpath.split('/').slice(-1)[0];
+  const tree = { name, children };
+
+  let samples = {};
+  let count = 0;
+  walkFileTree(tree, (entry, parent) => {
+    if (['wav', 'mp3'].includes(entry.name.split('.').slice(-1)[0])) {
+      samples[parent.name] = samples[parent.name] || [];
+      count += 1;
+      samples[parent.name].push(entry.subpath.slice(1).concat([entry.name]).join('/'));
+    }
+  });
+  const json = JSON.stringify(samples, null, 2);
+  const filepath = subpath + '/strudel.json';
+  await writeTextFile(filepath, json, { dir });
+  console.log(`wrote strudel.json with ${count} samples to ${subpath}!`);
+}
+
+registerSamplesPrefix(prefix, async (path) => {
+  const subpath = path.replace(prefix, '');
+  const hasJson = await hasStrudelJson(subpath);
+  if (!hasJson) {
+    await writeStrudelJson(subpath);
+  }
+  return loadStrudelJson(subpath);
+});
+
+export const walkFileTree = (node, fn) => {
+  if (!Array.isArray(node?.children)) {
+    return;
+  }
+  for (const entry of node.children) {
+    entry.subpath = (node.subpath || []).concat([node.name]);
+    fn(entry, node);
+    if (entry.children) {
+      walkFileTree(entry, fn);
+    }
+  }
+};
+
+export const isAudioFile = (filename) => ['wav', 'mp3'].includes(filename.split('.').slice(-1)[0]);
+
+function uint8ArrayToDataURL(uint8Array) {
+  const blob = new Blob([uint8Array], { type: 'audio/*' });
+  const dataURL = URL.createObjectURL(blob);
+  return dataURL;
+}
+
+const loadCache = {}; // caches local urls to data urls
+export async function resolveFileURL(url) {
+  if (loadCache[url]) {
+    return loadCache[url];
+  }
+  loadCache[url] = (async () => {
+    const contents = await readBinaryFile(url, { dir });
+    return uint8ArrayToDataURL(contents);
+  })();
+  return loadCache[url];
+}
+
+const fileResolver = (subpath) => (url) => resolveFileURL(subpath.endsWith('/') ? subpath + url : subpath + '/' + url);
+
+export async function playFile(path) {
+  const url = await resolveFileURL(path);
+  const ac = getAudioContext();
+  const bufferSource = ac.createBufferSource();
+  bufferSource.buffer = await loadBuffer(url, ac);
+  bufferSource.connect(ac.destination);
+  bufferSource.start(ac.currentTime);
+}

--- a/website/src/repl/files.mjs
+++ b/website/src/repl/files.mjs
@@ -7,7 +7,10 @@ import {
   loadBuffer,
 } from '@strudel.cycles/webaudio';
 
-const TAURI = window.__TAURI__;
+let TAURI;
+if (typeof window !== 'undefined') {
+  TAURI = window?.__TAURI__;
+}
 export const { BaseDirectory, readDir, readBinaryFile, writeTextFile, readTextFile, exists } = TAURI?.fs || {};
 
 export const dir = BaseDirectory?.Audio; // https://tauri.app/v1/api/js/path#audiodir

--- a/website/src/repl/prebake.mjs
+++ b/website/src/repl/prebake.mjs
@@ -1,6 +1,7 @@
 import { Pattern, noteToMidi, valueToMidi } from '@strudel.cycles/core';
 import { registerSynthSounds, samples } from '@strudel.cycles/webaudio';
 import './piano.mjs';
+import './files.mjs';
 
 export async function prebake() {
   // https://archive.org/details/SalamanderGrandPianoV3


### PR DESCRIPTION
when running the desktop app, it is now possible to load samples from disk via `samples('~/music/xxx')` where `xxx` is some path inside the machines music directory (see https://tauri.app/v1/api/js/path#audiodir).

The function will use the `strudel.json` inside that directory, or create one if it does not exist.

https://github.com/tidalcycles/strudel/assets/12023032/05bc2dba-b304-4298-9465-a1a6fafe5ded