### PR TITLE
fix: midi clock drift

### DIFF
--- a/packages/midi/midi.mjs
+++ b/packages/midi/midi.mjs
@@ -105,7 +105,7 @@ Pattern.prototype.midi = function (output) {
     hap.ensureObjectValue();
 
     // calculate time
-    const timingOffset = WebMidi.time - getAudioContext().currentTime * 1000;
+    const timingOffset = WebMidi.time - getAudioContext().getOutputTimestamp().contextTime * 1000;
     time = time * 1000 + timingOffset;
 
     // destructure value


### PR DESCRIPTION
mitigate / remove clock drift for midi output

ref: https://github.com/tidalcycles/strudel/issues/119