### PR TITLE
fix: update canvas size on window resize

### DIFF
--- a/packages/core/draw.mjs
+++ b/packages/core/draw.mjs
@@ -15,6 +15,14 @@ export const getDrawContext = (id = 'test-canvas') => {
     canvas.height = window.innerHeight;
     canvas.style = 'pointer-events:none;width:100%;height:100%;position:fixed;top:0;left:0';
     document.body.prepend(canvas);
+    let timeout;
+    window.addEventListener('resize', () => {
+      timeout && clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+      }, 200);
+    });
   }
   return canvas.getContext('2d');
 };

--- a/packages/core/spiral.mjs
+++ b/packages/core/spiral.mjs
@@ -68,8 +68,9 @@ Pattern.prototype.spiral = function (options = {}) {
   } = options;
 
   function spiral({ ctx, time, haps, drawTime }) {
-    ctx.clearRect(0, 0, ctx.canvas.clientWidth, ctx.canvas.clientHeight);
-    const [cx, cy] = [ctx.canvas.width / 2, ctx.canvas.height / 2];
+    const [w, h] = [ctx.canvas.width, ctx.canvas.height];
+    ctx.clearRect(0, 0, w * 2, h * 2);
+    const [cx, cy] = [w / 2, h / 2];
     const settings = {
       margin: size / stretch,
       cx,


### PR DESCRIPTION
resizing the window created strange artifacts on the desktop app when using spiral or punchcard