### PR TITLE
[Bug Fix] Account for numeral notation when converting to midi

### DIFF
--- a/packages/midi/midi.mjs
+++ b/packages/midi/midi.mjs
@@ -114,7 +114,7 @@ Pattern.prototype.midi = function (output) {
     const duration = hap.duration.valueOf() * 1000 - 5;
 
     if (note) {
-      const midiNumber = noteToMidi(note);
+      const midiNumber = typeof note === 'number' ? note : noteToMidi(note);
       device.playNote(midiNumber, midichan, {
         time,
         duration,


### PR DESCRIPTION
Discovered this bug when trying to use numeral notation with midi for example: 
`"12 7".note().midi('mymididevice').midichan(1)` 
would throw an error like 
`[cyclist] error: not a note: "7"`