### PR TITLE
[Bug Fix] Midi: Don't treat note 0 as false

### DIFF
--- a/packages/midi/midi.mjs
+++ b/packages/midi/midi.mjs
@@ -113,7 +113,7 @@ Pattern.prototype.midi = function (output) {
     const velocity = hap.context?.velocity ?? 0.9; // TODO: refactor velocity
     const duration = hap.duration.valueOf() * 1000 - 5;
 
-    if (note) {
+    if (note != null) {
       const midiNumber = typeof note === 'number' ? note : noteToMidi(note);
       device.playNote(midiNumber, midichan, {
         time,


### PR DESCRIPTION
This bug caused note 0 to be ignored.

I suspect there might be similar issues in other places in the app.
 For instance: if you do 
`"0".note().sound("triangle").pianoroll()`
it will display nothing in the piano roll and play a c2 and 
`"36".note().sound("triangle").pianoroll()`
will display in the piano roll and play a c2 as well
