### PR TITLE
Midi time fixes

### DIFF
--- a/packages/midi/midi.mjs
+++ b/packages/midi/midi.mjs
@@ -118,7 +118,7 @@ Pattern.prototype.midi = function (output) {
     const velocity = hap.context?.velocity ?? 0.9; // TODO: refactor velocity
 
     // note off messages will often a few ms arrive late, try to prevent glitching by subtracting from the duration length
-    const duration = Math.round(hap.duration.valueOf() * 1000 - 10);
+    const duration = hap.duration.valueOf() * 1000 - 10;
     if (note != null) {
       const midiNumber = typeof note === 'number' ? note : noteToMidi(note);
       const midiNote = new Note(midiNumber, { attack: velocity, duration });

--- a/packages/midi/midi.mjs
+++ b/packages/midi/midi.mjs
@@ -118,7 +118,7 @@ Pattern.prototype.midi = function (output) {
     const velocity = hap.context?.velocity ?? 0.9; // TODO: refactor velocity
 
     // note off messages will often a few ms arrive late, try to prevent glitching by subtracting from the duration length
-    const duration = hap.duration.valueOf() * 1000 - 10;
+    const duration = Math.floor(hap.duration.valueOf() * 1000 - 10);
     if (note != null) {
       const midiNumber = typeof note === 'number' ? note : noteToMidi(note);
       const midiNote = new Note(midiNumber, { attack: velocity, duration });


### PR DESCRIPTION
- implement the note offset more accurately using the method[ recommended by the api](https://webmidijs.org/api/classes/Output#playNote) "If time is a string prefixed with "+" and followed by a number, the message will be delayed by that many milliseconds." 

- use the Note constructor as recommended by the [api docs](https://webmidijs.org/api/classes/Note)

- fix small issue where listeners would sometimes not trigger or trigger many times and spam the console with the device initialization log message

- default to first IAC device if no devices is specified in pat.midi() and an IAC device exists. 

- adjust the duration offset slightly (from -5 to -10) to improve note glitching issues due to inconsistent duration/note off messages from the WebMidi API (this seems to be  worse in firefox than chromium