### PR TITLE
basic fm

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -110,6 +110,32 @@ const generic_params = [
   ['attack', 'att'],
 
   /**
+   * Sets the Frequency Modulation Harmonicity Ratio.
+   * Controls the timbre of the sound.
+   * Whole numbers and simple ratios sound more natural,
+   * while decimal numbers and complex ratios sound metallic.
+   *
+   * @name fmh
+   * @param {number | Pattern} harmonicity
+   * @example
+   * note("c e g b").fm(4).fmh("<1 2 1.5 1.61>")
+   *
+   */
+  [['fmh', 'fmi'], 'fmh'],
+  /**
+   * Sets the Frequency Modulation of the synth.
+   * Controls the modulation index, which defines the brightness of the sound.
+   *
+   * @name fm
+   * @param {number | Pattern} brightness modulation index
+   * @synonyms fmi
+   * @example
+   * note("c e g b").fm("<0 1 2 8 32>")
+   *
+   */
+  [['fmi', 'fmh'], 'fm'],
+
+  /**
    * Select the sound bank to use. To be used together with `s`. The bank name (+ "_") will be prepended to the value of `s`.
    *
    * @name bank

--- a/packages/superdough/synth.mjs
+++ b/packages/superdough/synth.mjs
@@ -17,8 +17,7 @@ const fm = (osc, harmonicityRatio, modulationIndex, wave = 'sine') => {
   const carrfreq = osc.frequency.value;
   const modfreq = carrfreq * harmonicityRatio;
   const modgain = modfreq * modulationIndex;
-  const { node: modulator, stop } = mod(modfreq, modgain, wave);
-  return { node: modulator, stop };
+  return mod(modfreq, modgain, wave);
 };
 
 export function registerSynthSounds() {

--- a/packages/superdough/synth.mjs
+++ b/packages/superdough/synth.mjs
@@ -1,5 +1,5 @@
 import { midiToFreq, noteToMidi } from './util.mjs';
-import { registerSound } from './superdough.mjs';
+import { registerSound, getAudioContext } from './superdough.mjs';
 import { getOscillator, gainNode, getEnvelope } from './helpers.mjs';
 
 const mod = (freq, range = 1, type = 'sine') => {

--- a/test/__snapshots__/examples.test.mjs.snap
+++ b/test/__snapshots__/examples.test.mjs.snap
@@ -1804,6 +1804,48 @@ exports[`runs examples > example "floor" example index 0 1`] = `
 ]
 `;
 
+exports[`runs examples > example "fm" example index 0 1`] = `
+[
+  "[ 0/1 → 1/4 | note:c fmi:0 ]",
+  "[ 1/4 → 1/2 | note:e fmi:0 ]",
+  "[ 1/2 → 3/4 | note:g fmi:0 ]",
+  "[ 3/4 → 1/1 | note:b fmi:0 ]",
+  "[ 1/1 → 5/4 | note:c fmi:1 ]",
+  "[ 5/4 → 3/2 | note:e fmi:1 ]",
+  "[ 3/2 → 7/4 | note:g fmi:1 ]",
+  "[ 7/4 → 2/1 | note:b fmi:1 ]",
+  "[ 2/1 → 9/4 | note:c fmi:2 ]",
+  "[ 9/4 → 5/2 | note:e fmi:2 ]",
+  "[ 5/2 → 11/4 | note:g fmi:2 ]",
+  "[ 11/4 → 3/1 | note:b fmi:2 ]",
+  "[ 3/1 → 13/4 | note:c fmi:8 ]",
+  "[ 13/4 → 7/2 | note:e fmi:8 ]",
+  "[ 7/2 → 15/4 | note:g fmi:8 ]",
+  "[ 15/4 → 4/1 | note:b fmi:8 ]",
+]
+`;
+
+exports[`runs examples > example "fmh" example index 0 1`] = `
+[
+  "[ 0/1 → 1/4 | note:c fmi:4 fmh:1 ]",
+  "[ 1/4 → 1/2 | note:e fmi:4 fmh:1 ]",
+  "[ 1/2 → 3/4 | note:g fmi:4 fmh:1 ]",
+  "[ 3/4 → 1/1 | note:b fmi:4 fmh:1 ]",
+  "[ 1/1 → 5/4 | note:c fmi:4 fmh:2 ]",
+  "[ 5/4 → 3/2 | note:e fmi:4 fmh:2 ]",
+  "[ 3/2 → 7/4 | note:g fmi:4 fmh:2 ]",
+  "[ 7/4 → 2/1 | note:b fmi:4 fmh:2 ]",
+  "[ 2/1 → 9/4 | note:c fmi:4 fmh:1.5 ]",
+  "[ 9/4 → 5/2 | note:e fmi:4 fmh:1.5 ]",
+  "[ 5/2 → 11/4 | note:g fmi:4 fmh:1.5 ]",
+  "[ 11/4 → 3/1 | note:b fmi:4 fmh:1.5 ]",
+  "[ 3/1 → 13/4 | note:c fmi:4 fmh:1.61 ]",
+  "[ 13/4 → 7/2 | note:e fmi:4 fmh:1.61 ]",
+  "[ 7/2 → 15/4 | note:g fmi:4 fmh:1.61 ]",
+  "[ 15/4 → 4/1 | note:b fmi:4 fmh:1.61 ]",
+]
+`;
+
 exports[`runs examples > example "focus" example index 0 1`] = `
 [
   "[ 0/1 → 1/8 | s:sd ]",

--- a/website/src/pages/learn/synths.mdx
+++ b/website/src/pages/learn/synths.mdx
@@ -28,4 +28,14 @@ The power of patterns allows us to sequence any _param_ independently:
 Now we not only pattern the notes, but the sound as well!
 `sawtooth` `square` and `triangle` are the basic waveforms available in `s`.
 
+## FM Synthesis
+
+### fm
+
+<JsDoc client:idle name="fm" h={0} />
+
+### fmh
+
+<JsDoc client:idle name="fmh" h={0} />
+
 Next up: [Audio Effects](/learn/effects)...


### PR DESCRIPTION
adds basic fm synthesis to the synth:

https://github.com/tidalcycles/strudel/assets/12023032/bfa72be9-bc5e-40e8-9541-63cffbbca27c

(in the video, fm = fmh, and fmi = fm ... i flipped this because it is probably more common to change the modulation index)

```js
note("c a f e")
.fm(4) // set modulation index to 4
```

```js
note("c a f e")
.fm(4)  // set modulation index to 4
.fmh(.5)  // set harmonicity to .5
```

`fm` is short for fmi, so you can also do

```js
note("c a f e")
.fmi(4)  // set modulation index to 4
.fmh(.5)  // set harmonicity to .5
```

array notation is also supported:

```js
note("c a f e").fm("4:2")
```