### PR TITLE
control osc partial count with n

### DIFF
--- a/packages/superdough/helpers.mjs
+++ b/packages/superdough/helpers.mjs
@@ -6,17 +6,6 @@ export function gainNode(value) {
   return node;
 }
 
-export const getOscillator = ({ s, freq, t }) => {
-  // make oscillator
-  const o = getAudioContext().createOscillator();
-  o.type = s || 'triangle';
-  o.frequency.value = Number(freq);
-  o.start(t);
-  //o.stop(t + duration + release);
-  const stop = (time) => o.stop(time);
-  return { node: o, stop };
-};
-
 // alternative to getADSR returning the gain node and a stop handle to trigger the release anytime in the future
 export const getEnvelope = (attack, decay, sustain, release, velocity, begin) => {
   const gainNode = getAudioContext().createGain();

--- a/packages/superdough/synth.mjs
+++ b/packages/superdough/synth.mjs
@@ -1,6 +1,6 @@
 import { midiToFreq, noteToMidi } from './util.mjs';
 import { registerSound, getAudioContext } from './superdough.mjs';
-import { getOscillator, gainNode, getEnvelope } from './helpers.mjs';
+import { gainNode, getEnvelope } from './helpers.mjs';
 
 const mod = (freq, range = 1, type = 'sine') => {
   const ctx = getAudioContext();
@@ -36,17 +36,17 @@ export function registerSynthSounds() {
         } = value;
         let { n, note, freq } = value;
         // with synths, n and note are the same thing
-        n = note || n || 36;
-        if (typeof n === 'string') {
-          n = noteToMidi(n); // e.g. c3 => 48
+        note = note || 36;
+        if (typeof note === 'string') {
+          note = noteToMidi(note); // e.g. c3 => 48
         }
         // get frequency
-        if (!freq && typeof n === 'number') {
-          freq = midiToFreq(n); // + 48);
+        if (!freq && typeof note === 'number') {
+          freq = midiToFreq(note); // + 48);
         }
         // maybe pull out the above frequency resolution?? (there is also getFrequency but it has no default)
         // make oscillator
-        const { node: o, stop } = getOscillator({ t, s: wave, freq });
+        const { node: o, stop } = getOscillator({ t, s: wave, freq, partials: n });
 
         let stopFm;
         if (fmModulationIndex) {
@@ -75,4 +75,50 @@ export function registerSynthSounds() {
       { type: 'synth', prebake: true },
     );
   });
+}
+
+export function waveformN(partials, type) {
+  const real = new Float32Array(partials + 1);
+  const imag = new Float32Array(partials + 1);
+  const ac = getAudioContext();
+  const osc = ac.createOscillator();
+
+  const amplitudes = {
+    sawtooth: (n) => 1 / n,
+    square: (n) => (n % 2 === 0 ? 0 : 1 / n),
+    triangle: (n) => (n % 2 === 0 ? 0 : 1 / (n * n)),
+  };
+
+  if (!amplitudes[type]) {
+    throw new Error(`unknown wave type ${type}`);
+  }
+
+  real[0] = 0; // dc offset
+  imag[0] = 0;
+  let n = 1;
+  while (n <= partials) {
+    real[n] = amplitudes[type](n);
+    imag[n] = 0;
+    n++;
+  }
+
+  const wave = ac.createPeriodicWave(real, imag);
+  osc.setPeriodicWave(wave);
+  return osc;
+}
+
+export function getOscillator({ s, freq, t, partials }) {
+  // make oscillator
+  let o;
+  if (!partials || s === 'sine') {
+    o = getAudioContext().createOscillator();
+    o.type = s || 'triangle';
+  } else {
+    o = waveformN(partials, s);
+  }
+  o.frequency.value = Number(freq);
+  o.start(t);
+  //o.stop(t + duration + release);
+  const stop = (time) => o.stop(time);
+  return { node: o, stop };
 }


### PR DESCRIPTION
for any of the simple waveforms, sawtooth, triangle, square (sine), this allows controlling the number of partials with the `n` control:

```js
note("c a f e")
.s("sawtooth:8") // <--- sawtooth wave with 8 partials
```

This allows creating less harsh waveforms with additive synthesis directly, without needing a filter, which is more to write.

This is actually a breaking change, because `n` could prior be used to control the oscillator pitch, as a synonym for `note`.
I think this synonym, which only works with oscillators is more confusing than helpful, as it sometimes works ( waveforms ) and sometimes not ( samples: picks another sample ). The behavior of `n` to choose partial count for oscillators complements the behavior of `n` to pick a sample variant, as it is also timbre related..

@yaxu what do you think? I think tidal also has this separation of `n` for samples and synths? 
If you don't think this is a good idea, I could also add a `partials` control instead...

edit: the problem with an extra control for this is that you cannot use it with ":" notation, so you'd have to write `s("sawtooth").partials(8)` instead of `s("sawtooth:8")` because the second item in `s` is always bound to `n`.
Right now, that second item is not really usefull for waveforms

also, it might make sense to limit the number of partials to 64 or something

fixes https://github.com/tidalcycles/strudel/issues/191
related: https://github.com/tidalcycles/strudel/discussions/395
