### PR TITLE
Supporting custom FM waveform for modulator

### DIFF
--- a/packages/superdough/helpers.mjs
+++ b/packages/superdough/helpers.mjs
@@ -39,6 +39,19 @@ export const getEnvelope = (attack, decay, sustain, release, velocity, begin) =>
   };
 };
 
+export const getExpEnvelope = (attack, decay, velocity, begin) => {
+  const gainNode = getAudioContext().createGain();
+  gainNode.gain.setValueAtTime(0.0001, begin);
+  gainNode.gain.exponentialRampToValueAtTime(velocity, begin + attack);
+  gainNode.gain.exponentialRampToValueAtTime(0.0001, begin + attack + decay);
+  return {
+    node: gainNode,
+    stop: (t) => {
+      gainNode.gain.exponentialRampToValueAtTime(0.0001, t + decay);
+    },
+  };
+};
+
 export const getADSR = (attack, decay, sustain, release, velocity, begin, end) => {
   const gainNode = getAudioContext().createGain();
   gainNode.gain.setValueAtTime(0, begin);

--- a/packages/superdough/helpers.mjs
+++ b/packages/superdough/helpers.mjs
@@ -39,19 +39,6 @@ export const getEnvelope = (attack, decay, sustain, release, velocity, begin) =>
   };
 };
 
-export const getExpEnvelope = (attack, decay, velocity, begin) => {
-  const gainNode = getAudioContext().createGain();
-  gainNode.gain.setValueAtTime(0.0001, begin);
-  gainNode.gain.exponentialRampToValueAtTime(velocity, begin + attack);
-  gainNode.gain.exponentialRampToValueAtTime(0.0001, begin + attack + decay);
-  return {
-    node: gainNode,
-    stop: (t) => {
-      gainNode.gain.exponentialRampToValueAtTime(0.0001, t + decay);
-    },
-  };
-};
-
 export const getADSR = (attack, decay, sustain, release, velocity, begin, end) => {
   const gainNode = getAudioContext().createGain();
   gainNode.gain.setValueAtTime(0, begin);

--- a/packages/superdough/synth.mjs
+++ b/packages/superdough/synth.mjs
@@ -3,7 +3,6 @@ import { registerSound, getAudioContext } from './superdough.mjs';
 import { getOscillator, gainNode, getEnvelope } from './helpers.mjs';
 
 const mod = (freq, range = 1, type) => {
-	console.log(type)
   const ctx = getAudioContext();
   const osc = ctx.createOscillator();
   osc.type = type;

--- a/packages/superdough/synth.mjs
+++ b/packages/superdough/synth.mjs
@@ -2,7 +2,8 @@ import { midiToFreq, noteToMidi } from './util.mjs';
 import { registerSound, getAudioContext } from './superdough.mjs';
 import { getOscillator, gainNode, getEnvelope } from './helpers.mjs';
 
-const mod = (freq, range = 1, type = 'sine') => {
+const mod = (freq, range = 1, type) => {
+	console.log(type)
   const ctx = getAudioContext();
   const osc = ctx.createOscillator();
   osc.type = type;
@@ -13,7 +14,7 @@ const mod = (freq, range = 1, type = 'sine') => {
   return { node: g, stop: (t) => osc.stop(t) };
 };
 
-const fm = (osc, harmonicityRatio, modulationIndex, wave = 'sine') => {
+const fm = (osc, harmonicityRatio, modulationIndex, wave) => {
   const carrfreq = osc.frequency.value;
   const modfreq = carrfreq * harmonicityRatio;
   const modgain = modfreq * modulationIndex;
@@ -33,6 +34,7 @@ export function registerSynthSounds() {
           release = 0.01,
           fmh: fmHarmonicity = 1,
           fmi: fmModulationIndex,
+					fmwave: fmWaveform = 'sine'
         } = value;
         let { n, note, freq } = value;
         // with synths, n and note are the same thing
@@ -50,7 +52,11 @@ export function registerSynthSounds() {
 
         let stopFm;
         if (fmModulationIndex) {
-          const { node: modulator, stop } = fm(o, fmHarmonicity, fmModulationIndex);
+          const { node: modulator, stop } = fm(
+						o, fmHarmonicity, 
+						fmModulationIndex, 
+						fmWaveform
+					);
           modulator.connect(o.frequency);
           stopFm = stop;
         }

--- a/packages/superdough/synth.mjs
+++ b/packages/superdough/synth.mjs
@@ -1,6 +1,6 @@
 import { midiToFreq, noteToMidi } from './util.mjs';
 import { registerSound, getAudioContext } from './superdough.mjs';
-import { getOscillator, gainNode, getEnvelope, getExpEnvelope } from './helpers.mjs';
+import { getOscillator, gainNode, getEnvelope } from './helpers.mjs';
 
 const mod = (freq, range = 1, type) => {
   const ctx = getAudioContext();
@@ -13,38 +13,10 @@ const mod = (freq, range = 1, type) => {
   return { node: g, stop: (t) => osc.stop(t) };
 };
 
-const fm = (t, 
-	osc, 
-	harmonicityRatio, 
-	harmonicityAttack,
-	harmonicityDecay,
-	modulationIndex, 
-	modulationAttack,
-	modulationDecay,
-	wave, ) => {
-
+const fm = (osc, harmonicityRatio, modulationIndex, wave) => {
   const carrfreq = osc.frequency.value;
-	let modfreq;
-	let modgain;
-
-	// Setting up envelopes if needed
-	if ((harmonicityAttack !== null) || (harmonicityDecay !== null)) {
-		let hattack = harmonicityAttack || 0.01;
-		let hdecay = harmonicityDecay || 0.5;
-		const harmonicEnv = getExpEnvelope(hattack, hdecay, 1, t);
-		modfreq = carrfreq * (harmonicityRatio * harmonicEnv);
-	} else {
-		modfreq = carrfreq * harmonicityRatio;
-	}
-	if ((modulationAttack !== null) || (modulationDecay !== null)) {
-		let mattack = modulationAttack || 0.01;
-		let mdecay = modulationDecay || 0.5;
-		const modulationEnv = getExpEnvelope(mattack, mdecay, 1, t);
-		modgain = modfreq * (modulationIndex * modulationEnv);
-	} else {
-		modgain = modfreq * modulationIndex;
-	}
-
+  const modfreq = carrfreq * harmonicityRatio;
+  const modgain = modfreq * modulationIndex;
   return mod(modfreq, modgain, wave);
 };
 
@@ -60,12 +32,8 @@ export function registerSynthSounds() {
           sustain = 0.6,
           release = 0.01,
           fmh: fmHarmonicity = 1,
-					fmhattack: fmHarmonicityAttack = null,
-					fmhdecay: fmHarmonicityDecay = null,
           fmi: fmModulationIndex,
-					fmiattack: fmModulationAttack = null,
-					fmidecay: fmModulationDecay = null,
-					fmwave: fmWaveform = 'sine',
+					fmwave: fmWaveform = 'sine'
         } = value;
         let { n, note, freq } = value;
         // with synths, n and note are the same thing
@@ -84,15 +52,9 @@ export function registerSynthSounds() {
         let stopFm;
         if (fmModulationIndex) {
           const { node: modulator, stop } = fm(
-						t, 
-						o, 
-						fmHarmonicity, 
-						fmHarmonicityAttack,
-						fmHarmonicityDecay,
+						o, fmHarmonicity, 
 						fmModulationIndex, 
-						fmModulationAttack,
-						fmModulationDecay,
-						fmWaveform,
+						fmWaveform
 					);
           modulator.connect(o.frequency);
           stopFm = stop;


### PR DESCRIPTION
The FM implementation was defaulting to usine a sine wave for its unique modulator. You can now choose the modulator waveform type using the `fmwave` parameter. This argument is expecting a string: `sine`, `triangle`, `sawtooth`, `square`. 

This should open up the FM territory a bit more.