### PR TITLE
add midi clock support

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -1066,6 +1066,7 @@ const generic_params = [
    */
   ['waveloss'],
   // TODO: midi effects?
+  ['clock'],
   ['dur'],
   // ['modwheel'],
   ['expression'],

--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -1066,7 +1066,7 @@ const generic_params = [
    */
   ['waveloss'],
   // TODO: midi effects?
-  ['clock'],
+  ['midicmd'],
   ['dur'],
   // ['modwheel'],
   ['expression'],

--- a/packages/midi/midi.mjs
+++ b/packages/midi/midi.mjs
@@ -78,6 +78,20 @@ function getDevice(output, outputs) {
   return IACOutput ?? outputs[0];
 }
 
+// send start/stop messages to outputs when repl starts/stops
+if (typeof window !== 'undefined') {
+  window.addEventListener('message', (e) => {
+    if (!WebMidi?.enabled) {
+      return;
+    }
+    if (e.data === 'strudel-stop') {
+      WebMidi.outputs.forEach((output) => output.sendStop());
+    } else if (e.data === 'strudel-start') {
+      WebMidi.outputs.forEach((output) => output.sendStart());
+    }
+  });
+}
+
 Pattern.prototype.midi = function (output) {
   if (isPattern(output)) {
     throw new Error(

--- a/packages/midi/midi.mjs
+++ b/packages/midi/midi.mjs
@@ -86,9 +86,8 @@ if (typeof window !== 'undefined') {
     }
     if (e.data === 'strudel-stop') {
       WebMidi.outputs.forEach((output) => output.sendStop());
-    } else if (e.data === 'strudel-start') {
-      WebMidi.outputs.forEach((output) => output.sendStart());
     }
+    // cannot start here, since we have no timing info, see sendStart below
   });
 }
 
@@ -149,6 +148,10 @@ Pattern.prototype.midi = function (output) {
       }
       const scaled = Math.round(ccv * 127);
       device.sendControlChange(ccn, scaled, midichan, { time: timeOffsetString });
+    }
+    if (hap.whole.begin + 0 === 0) {
+      // we need to start here because we have the timing info
+      device.sendStart({ time: timeOffsetString });
     }
     if (['clock', 'midiClock'].includes(midicmd)) {
       device.sendClock({ time: timeOffsetString });

--- a/packages/superdough/dspworklet.mjs
+++ b/packages/superdough/dspworklet.mjs
@@ -14,7 +14,6 @@ class MyProcessor extends AudioWorkletProcessor {
       if(e.data==='stop') {
         this.stopped = true;
       } else if(e.data?.dough) {
-        const deadline = e.data.time-currentTime;
         __q.push(e.data)
       } else {
         msg?.(e.data)

--- a/packages/superdough/package.json
+++ b/packages/superdough/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superdough",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "simple web audio synth and sampler intended for live coding. inspired by superdirt and webdirt.",
   "main": "index.mjs",
   "type": "module",

--- a/website/src/repl/Repl.jsx
+++ b/website/src/repl/Repl.jsx
@@ -33,7 +33,7 @@ const supabase = createClient(
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBpZHhkc3hwaGxoempuem1pZnRoIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NTYyMzA1NTYsImV4cCI6MTk3MTgwNjU1Nn0.bqlw7802fsWRnqU5BLYtmXk_k-D1VFmbkHMywWc15NM',
 );
 
-const modules = [
+let modules = [
   import('@strudel.cycles/core'),
   import('@strudel.cycles/tonal'),
   import('@strudel.cycles/mini'),
@@ -45,13 +45,13 @@ const modules = [
   import('@strudel.cycles/csound'),
 ];
 if (isTauri()) {
-  modules.concat([
+  modules = modules.concat([
     import('@strudel/desktopbridge/loggerbridge.mjs'),
     import('@strudel/desktopbridge/midibridge.mjs'),
     import('@strudel/desktopbridge/oscbridge.mjs'),
   ]);
 } else {
-  modules.concat([import('@strudel.cycles/midi'), import('@strudel.cycles/osc')]);
+  modules = modules.concat([import('@strudel.cycles/midi'), import('@strudel.cycles/osc')]);
 }
 
 const modulesLoading = evalScope(
@@ -153,6 +153,8 @@ export function Repl({ embedded = false }) {
         if (!play) {
           cleanupDraw(false);
           window.postMessage('strudel-stop');
+        } else {
+          window.postMessage('strudel-start');
         }
       },
       drawContext,


### PR DESCRIPTION
fixes https://github.com/tidalcycles/strudel/issues/709

usage:

```js
stack(
  s("hh*4"),
  midicmd("clock*48").midi('IAC-Treiber Bus 1')
)
```

This allows manipulating the clock itself with a pattern :)
Additionally, it will fire a midi start event when the repl is started to make sure the clock is in phase.
On the very first start, it might behave weird when midi is not initialized yet...

edit: adjusted for new syntax