### PR TITLE
Slider afterthoughts

### DIFF
--- a/packages/codemirror/slider.mjs
+++ b/packages/codemirror/slider.mjs
@@ -6,7 +6,7 @@ export let sliderValues = {};
 const getSliderID = (from) => `slider_${from}`;
 
 export class SliderWidget extends WidgetType {
-  constructor(value, min, max, from, to, view) {
+  constructor(value, min, max, from, to, step, view) {
     super();
     this.value = value;
     this.min = min;
@@ -14,6 +14,7 @@ export class SliderWidget extends WidgetType {
     this.from = from;
     this.originalFrom = from;
     this.to = to;
+    this.step = step;
     this.view = view;
   }
 
@@ -29,7 +30,7 @@ export class SliderWidget extends WidgetType {
     slider.type = 'range';
     slider.min = this.min;
     slider.max = this.max;
-    slider.step = (this.max - this.min) / 1000;
+    slider.step = this.step ?? (this.max - this.min) / 1000;
     slider.originalValue = this.value;
     // to make sure the code stays in sync, let's save the original value
     // becuase .value automatically clamps values so it'll desync with the code
@@ -66,9 +67,9 @@ export const updateWidgets = (view, widgets) => {
 };
 
 function getWidgets(widgetConfigs, view) {
-  return widgetConfigs.map(({ from, to, value, min, max }) => {
+  return widgetConfigs.map(({ from, to, value, min, max, step }) => {
     return Decoration.widget({
-      widget: new SliderWidget(value, min, max, from, to, view),
+      widget: new SliderWidget(value, min, max, from, to, step, view),
       side: 0,
     }).range(from /* , to */);
   });

--- a/packages/codemirror/slider.mjs
+++ b/packages/codemirror/slider.mjs
@@ -91,8 +91,10 @@ export const sliderPlugin = ViewPlugin.fromClass(
           while (iterator.value) {
             // when the widgets are moved, we need to tell the dom node the current position
             // this is important because the updateSliderValue function has to work with the dom node
-            iterator.value.widget.slider.from = iterator.from;
-            iterator.value.widget.slider.to = iterator.to;
+            if (iterator.value?.widget?.slider) {
+              iterator.value.widget.slider.from = iterator.from;
+              iterator.value.widget.slider.to = iterator.to;
+            }
             iterator.next();
           }
         }

--- a/packages/transpiler/transpiler.mjs
+++ b/packages/transpiler/transpiler.mjs
@@ -43,6 +43,7 @@ export function transpiler(input, options = {}) {
             value: node.arguments[0].raw, // don't use value!
             min: node.arguments[1]?.value ?? 0,
             max: node.arguments[2]?.value ?? 1,
+            step: node.arguments[3]?.value,
           });
         return this.replace(widgetWithLocation(node));
       }


### PR DESCRIPTION
- add step argument, so there is now `slider(value, min, max, step)` e.g. `slider(2,1,8,1)` will output integers between 1 and 8. the default step is 1/1000 of the total range
- fix a bug where the sliders plugin crashed 