### PR TITLE
fix: reverb roomsize not required

### DIFF
--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -382,7 +382,7 @@ export const superdough = async (value, deadline, hapDuration) => {
   }
   // reverb
   let reverbSend;
-  if (room > 0 && roomsize > 0) {
+  if (room > 0) {
     const reverbNode = getReverb(orbit, roomsize, roomfade, roomlp, roomdim);
     reverbSend = effectSend(post, reverbNode, room);
   }


### PR DESCRIPTION
as before the new reverb was added, only setting room should be required to get a reverb