### PR TITLE
fix: try different trailing slash behavior

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -45,9 +45,9 @@ const options = {
 
 // https://astro.build/config
 export default defineConfig({
-  trailingSlash: 'always',
+  trailingSlash: 'never',
   build: {
-    format: 'directory',
+    format: 'file',
   },
   integrations: [
     react(),


### PR DESCRIPTION
PR https://github.com/tidalcycles/strudel/pull/743 didn't work as expected: trailing slash URLs worked, but without it did not. This PR might flip this behavior, with a tiny chance of fixing it. I don't know how github pages plays into this so deployment is needed for testing