### PR TITLE
add play function

### DIFF
--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -24,6 +24,7 @@ export function repl({
     getTime,
     onToggle,
   });
+  let playPatterns = [];
   const setPattern = (pattern, autostart = true) => {
     pattern = editPattern?.(pattern) || pattern;
     scheduler.setPattern(pattern, autostart);
@@ -35,7 +36,11 @@ export function repl({
     }
     try {
       await beforeEval?.({ code });
+      playPatterns = [];
       let { pattern, meta } = await _evaluate(code, transpiler);
+      if (playPatterns.length) {
+        pattern = pattern.stack(...playPatterns);
+      }
       logger(`[eval] code updated`);
       setPattern(pattern, autostart);
       afterEval?.({ code, pattern, meta });
@@ -57,6 +62,10 @@ export function repl({
     return pat.loopAtCps(cycles, scheduler.cps);
   });
 
+  const play = register('play', (pat) => {
+    playPatterns.push(pat);
+  });
+
   const fit = register('fit', (pat) =>
     pat.withHap((hap) =>
       hap.withValue((v) => ({
@@ -70,6 +79,7 @@ export function repl({
   evalScope({
     loopAt,
     fit,
+    play,
     setCps,
     setcps: setCps,
     setCpm,

--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -64,6 +64,7 @@ export function repl({
 
   const play = register('play', (pat) => {
     playPatterns.push(pat);
+    return pat;
   });
 
   const fit = register('fit', (pat) =>


### PR DESCRIPTION
The play function allows adding a pattern to the scheduler, as an alternative to stacking it in the bottom:

```js
stack(
  s("bd"),
  s("~ cp")
)
```

can now also be written as

```js
s("bd").play()
s("~ cp").play()
```

this is also how it already works in https://github.com/tidalcycles/strudel/tree/main/packages/web