### PR TITLE
fix: style issues

### DIFF
--- a/website/src/docs/MiniRepl.css
+++ b/website/src/docs/MiniRepl.css
@@ -1,26 +1,26 @@
-.cm-activeLine,
-.cm-activeLineGutter {
+.mini-repl .cm-activeLine,
+.mini-repl .cm-activeLineGutter {
   background-color: transparent !important;
 }
 
-.cm-theme {
+.mini-repl .cm-theme {
   background-color: var(--background);
   border: 1px solid var(--lineHighlight);
   padding: 2px;
 }
 
-.cm-scroller {
+.mini-repl .cm-scroller {
   font-family: inherit !important;
 }
 
-.cm-gutters {
+.mini-repl .cm-gutters {
   display: none !important;
 }
 
-.cm-cursorLayer {
+.mini-repl .cm-cursorLayer {
   animation-name: inherit !important;
 }
 
-.cm-cursor {
+.mini-repl .cm-cursor {
   border-left: 2px solid currentcolor !important;
 }

--- a/website/src/docs/MiniRepl.jsx
+++ b/website/src/docs/MiniRepl.jsx
@@ -51,7 +51,7 @@ export function MiniRepl({
       .catch((err) => console.error(err));
   }, []);
   return Repl ? (
-    <div className="mb-4">
+    <div className="mb-4 mini-repl">
       <Repl
         tune={tune}
         hideOutsideView={true}


### PR DESCRIPTION
fixes https://github.com/tidalcycles/strudel/issues/778 + some other style problems, e.g. the viz was hidden behind the code.

It seems the style resolution changed once again after updating astro to version 4.. related: https://github.com/tidalcycles/strudel/issues/568

it seems that the dev server is behaving differently compared to the production version:

- in dev, styles are scoped to where they are imported, e.g. MiniRepl.css only affects MiniRepl.jsx where it is imported
- in production, styles are global, so everything in MiniRepl.css is affecting the whole page. this was different before..

I fixed it by adding an extra class for the mini repl container to be able to namespace all the related styles in MiniRepl.css

At some point it might make sense to dive deeper into how styles should be properly used, but for now, it is a quick fix