### PR TITLE
poc: fraction shorthands

### DIFF
--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -9,7 +9,7 @@ import Fraction from './fraction.mjs';
 import Hap from './hap.mjs';
 import State from './state.mjs';
 import { unionWithObj } from './value.mjs';
-
+import { char2fraction } from './util.mjs';
 import { compose, removeUndefineds, flatten, id, listRange, curry, _mod, numeralArgs, parseNumeral } from './util.mjs';
 import drawLine from './drawLine.mjs';
 import { logger } from './logger.mjs';
@@ -1903,6 +1903,7 @@ export const when = register('when', function (on, func, pat) {
  * "c3 eb3 g3".off(1/8, x=>x.add(7)).note()
  */
 export const off = register('off', function (time_pat, func, pat) {
+  time_pat = char2fraction(time_pat);
   return stack(pat, func(pat.late(time_pat)));
 });
 

--- a/packages/core/util.mjs
+++ b/packages/core/util.mjs
@@ -1,3 +1,5 @@
+import Fraction from './fraction.mjs';
+
 /*
 util.mjs - <short description TODO>
 Copyright (C) 2022 Strudel contributors - see <https://github.com/tidalcycles/strudel/blob/main/packages/core/util.mjs>
@@ -273,4 +275,22 @@ export const sol2note = (n, notation = 'letters') => {
   const note = pc[n % 12]; /*calculating the midi value to the note*/
   const oct = Math.floor(n / 12) - 1;
   return note + oct;
+};
+
+const fractionCharacters = {
+  w: Fraction(1),
+  h: Fraction(0.5),
+  q: Fraction(0.25),
+  e: Fraction(0.125),
+  s: Fraction(0.0625),
+  t: Fraction(1 / 3),
+  f: Fraction(0.2),
+  x: Fraction(1 / 6),
+};
+const validFractionCharacters = Object.keys(fractionCharacters);
+export const char2fraction = (maybeChar) => {
+  if (typeof maybeChar === 'string' && validFractionCharacters.includes(maybeChar)) {
+    return fractionCharacters[maybeChar];
+  }
+  return maybeChar;
 };


### PR DESCRIPTION
this is how fraction shorthands could be implemented without a type system / type inference.
just let each function decide which params should be parsed as fraction shorthands..
To finish this, all functions that allow fraction shorthands should get this treatment