### PR TITLE
tidal style d1 ... d9 functions + more

### DIFF
--- a/packages/core/evaluate.mjs
+++ b/packages/core/evaluate.mjs
@@ -47,10 +47,5 @@ export const evaluate = async (code, transpiler) => {
   // if no transpiler is given, we expect a single instruction (!wrapExpression)
   const options = { wrapExpression: !!transpiler };
   let evaluated = await safeEval(code, options);
-  if (!isPattern(evaluated)) {
-    console.log('evaluated', evaluated);
-    const message = `got "${typeof evaluated}" instead of pattern`;
-    throw new Error(message + (typeof evaluated === 'function' ? ', did you forget to call a function?' : '.'));
-  }
   return { mode: 'javascript', pattern: evaluated, meta };
 };

--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -1975,9 +1975,9 @@ export const press = register('press', function (pat) {
  *   s("hh*3")
  * )
  */
-export const hush = register('hush', function (pat) {
+Pattern.prototype.hush = function () {
   return silence;
-});
+};
 
 /**
  * Applies `rev` to a pattern every other cycle, so that the pattern alternates between forwards and backwards.

--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -1178,7 +1178,7 @@ export function reify(thing) {
  * @return {Pattern}
  * @synonyms polyrhythm, pr
  * @example
- * stack(g3, b3, [e4, d4]).note() // "g3,b3,[e4,d4]".note()
+ * stack("g3", "b3", ["e4", "d4"]).note() // "g3,b3,[e4,d4]".note()
  */
 export function stack(...pats) {
   // Array test here is to avoid infinite recursions..
@@ -1193,7 +1193,7 @@ export function stack(...pats) {
  *
  * @return {Pattern}
  * @example
- * slowcat(e5, b4, [d5, c5])
+ * slowcat("e5", "b4", ["d5", "c5"])
  *
  */
 export function slowcat(...pats) {
@@ -1237,7 +1237,7 @@ export function slowcatPrime(...pats) {
  * @synonyms slowcat
  * @return {Pattern}
  * @example
- * cat(e5, b4, [d5, c5]).note() // "<e5 b4 [d5 c5]>".note()
+ * cat("e5", "b4", ["d5", "c5"]).note() // "<e5 b4 [d5 c5]>".note()
  *
  */
 export function cat(...pats) {
@@ -1247,7 +1247,7 @@ export function cat(...pats) {
 /** Like {@link Pattern.seq}, but each step has a length, relative to the whole.
  * @return {Pattern}
  * @example
- * timeCat([3,e3],[1, g3]).note() // "e3@3 g3".note()
+ * timeCat([3,"e3"],[1, "g3"]).note() // "e3@3 g3".note()
  */
 export function timeCat(...timepats) {
   const total = timepats.map((a) => a[0]).reduce((a, b) => a.add(b), Fraction(0));
@@ -1287,7 +1287,7 @@ export function sequence(...pats) {
 /** Like **cat**, but the items are crammed into one cycle.
  * @synonyms fastcat, sequence
  * @example
- * seq(e5, b4, [d5, c5]).note() // "e5 b4 [d5 c5]".note()
+ * seq("e5", "b4", ["d5", "c5"]).note() // "e5 b4 [d5 c5]".note()
  *
  */
 export function seq(...pats) {

--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -87,6 +87,7 @@ export function repl({
 
   const all = function (transform) {
     allTransform = transform;
+    return silence;
   };
 
   for (let i = 1; i < 10; ++i) {
@@ -95,6 +96,7 @@ export function repl({
         return this.p(i);
       },
     });
+    Pattern.prototype[`q${i}`] = silence;
   }
 
   const fit = register('fit', (pat) =>

--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -96,6 +96,11 @@ export function repl({
         return this.p(i);
       },
     });
+    Object.defineProperty(Pattern.prototype, `p${i}`, {
+      get() {
+        return this.p(i);
+      },
+    });
     Pattern.prototype[`q${i}`] = silence;
   }
 

--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -3,7 +3,7 @@ import { evaluate as _evaluate } from './evaluate.mjs';
 import { logger } from './logger.mjs';
 import { setTime } from './time.mjs';
 import { evalScope } from './evaluate.mjs';
-import { register, Pattern, isPattern } from './pattern.mjs';
+import { register, Pattern, isPattern, silence, stack } from './pattern.mjs';
 
 export function repl({
   interval,

--- a/packages/transpiler/test/transpiler.test.mjs
+++ b/packages/transpiler/test/transpiler.test.mjs
@@ -17,9 +17,6 @@ describe('transpiler', () => {
   it('wraps backtick string with mini and adds location', () => {
     expect(transpiler('`c3`', simple).output).toEqual("m('c3', 0);");
   });
-  it('replaces note variables with note strings', () => {
-    expect(transpiler('seq(c3, d3)', simple).output).toEqual("seq('c3', 'd3');");
-  });
   it('keeps tagged template literal as is', () => {
     expect(transpiler('xxx`c3`', simple).output).toEqual('xxx`c3`;');
   });

--- a/packages/transpiler/transpiler.mjs
+++ b/packages/transpiler/transpiler.mjs
@@ -47,11 +47,6 @@ export function transpiler(input, options = {}) {
           });
         return this.replace(widgetWithLocation(node));
       }
-      // TODO: remove pseudo note variables?
-      if (node.type === 'Identifier' && isNoteWithOctave(node.name)) {
-        this.skip();
-        return this.replace({ type: 'Literal', value: node.name });
-      }
     },
     leave(node, parent, prop, index) {},
   });


### PR DESCRIPTION
this is an attempt in adding tidal style d1 ... d9 functions + the p function and an additional q function, while still being backwards compatible with the old strudel style of not using any of these functions:

- `pPatterns` maps identifiers to patterns
- before each evaluation, `pPatterns` is cleared
- on evaluation, `.p(id)` sets the calling pattern on `pPatterns` using the given `id` as key
- after evaluation, if at least one key is found in `pPatterns`, the pattern used for playback is a stack of all `pPatterns`
- after evaluation, if `pPatterns` is empty, the old behavior is used, so the last expression is expected to be a pattern
- `.d1` ... `.d9` are just shortcuts for `.p(1)` ... `.p(9)`

so for example:

```js
s("bd").d1
s("hh*2").d2
```

will play both patterns stacked, as `pPatterns` will be `{1: s("bd"), 2: s("hh*2") }`.

```js
s("bd").d1
s("hh*2").d1
```

Here, `s("hh*2")` will win. 

Also, This still works:

```js
s("hh*2")
```

There is now also the `all` function:

```js
all(set(gain(.5)))
```

.. which just takes in a function that is applied to the evaluated pattern at the end.

+ I've also added a `shouldHush` flag that can be set on the `evaluate` function. 
If it is true, the evaluation will not clear the `pPatterns`, meaning you could do block based evaluation (with hidden state).

breaking changes:

There is now also a new top level hush function that will clear pPatterns and return silence (actually the hush function did exist before but it was just the non chained variant of `.hush()` which is not useful at all i think).

To support .d1 to .d9, i had to remove the transpiler feature that turns note variables into note strings, as it interfered with it. I don't think anyone really uses this feature, as mini notation is just more practical + it can also be confusing when you cannot name your variable after a note name..