### PR TITLE
CHANGES: github action pnpm version from 7 to 8.3.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8.3.1
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8.3.1
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
To make sure we're using the same version of `pnpm` in the github actions as we're communicating in [CONTRIBUTIONS.md](https://github.com/tidalcycles/strudel/compare/main...bwagner:strudel:contributions_fix) (presupposing that PR #834 gets merged) and as communicated on [discord](https://discord.com/channels/779427371270275082/1180300020088578120/1180991961189072956).