### PR TITLE
Prevent 404 on Algolia crawls

### DIFF
--- a/website/src/pages/learn/csound.mdx
+++ b/website/src/pages/learn/csound.mdx
@@ -145,7 +145,7 @@ In both cases, p4 is derived from the value of `freq` or `note`.
 ## Limitations / Future Plans
 
 Apart from the above listed p values, no other parameter can be patterned so far.
-This also means that [audio effects](./learn/effects) will not work.
+This also means that [audio effects](/learn/effects/) will not work.
 In the future, the integration could be improved by passing all patterned control parameters to the csound instrument.
 This could work by a unique [channel](https://kunstmusik.github.io/icsc2022-csound-web/tutorial2-interacting-with-csound/#step-4---writing-continuous-data-channels)
 for each value. Channels could be read [like this](https://github.com/csound/csound/blob/master/Android/CsoundForAndroid/CsoundAndroidExamples/src/main/res/raw/multitouch_xy.csd).

--- a/website/src/pages/learn/getting-started.mdx
+++ b/website/src/pages/learn/getting-started.mdx
@@ -41,7 +41,7 @@ This interactive tutorial will guide you through the basics of Strudel.
 To see and hear what Strudel can do, visit the [Strudel REPL](https://strudel.cc/) and click the Shuffle icon in the top menu bar.
 You can get a feel for Strudel by browsing and editing these examples and clicking the Refresh icon to update.
 
-You can also browse through the examples [here](./examples).
+You can also browse through the examples [here](/examples).
 
 Alternatively, you can get a taste of what Strudel can do by clicking play on this track:
 

--- a/website/src/pages/learn/sounds.mdx
+++ b/website/src/pages/learn/sounds.mdx
@@ -19,7 +19,7 @@ You can learn more about both of these approaches in the pages [Synths](/learn/s
 
 # Combining notes and sounds
 
-In both of the above cases, we are no longer directly controlling the `note`/`freq` of the sound heard via `s`, as we were in the [Notes](/strudel/notes) page.
+In both of the above cases, we are no longer directly controlling the `note`/`freq` of the sound heard via `s`, as we were in the [Notes](/workshop/first-notes/) page.
 
 So how can we both control the sound and the pitch? We can _combine_ `note`/`freq` with `s` to change the sound of our pitches:
 

--- a/website/src/pages/learn/strudel-vs-tidal.mdx
+++ b/website/src/pages/learn/strudel-vs-tidal.mdx
@@ -96,13 +96,13 @@ If you find a tidal control that's not on the list, please tell!
 ## Sound
 
 Tidal is commonly paired with Superdirt / Supercollider for sound generation.
-While Strudel also has a way of [communicating with Superdirt](./learn/input-output),
+While Strudel also has a way of [communicating with Superdirt](/learn/input-output/),
 it aims to provide a standalone live coding environment that runs entirely in the browser.
 
 ### Audio Effects
 
 Many of SuperDirt's effects have been reimplemented in Strudel, using the Web Audio API.
-You can find a [list of available effects here](./learn/effects).
+You can find a [list of available effects here](/learn/effects/).
 
 ### Sampler
 

--- a/website/src/pages/learn/time-modifiers.mdx
+++ b/website/src/pages/learn/time-modifiers.mdx
@@ -110,4 +110,4 @@ Some of these have equivalent operators in the Mini Notation:
 
 <JsDoc client:idle name="ribbon" h={0} />
 
-Apart from modifying time, there are ways to [Control Parameters](functions/value-modifiers).
+Apart from modifying time, there are ways to [Control Parameters](/functions/value-modifiers/).


### PR DESCRIPTION
URLS starting by "./" are correctly interpreted by browsers but it makes Algolia crawler follow a bad link such as https://strudel.cc/learn/time-modifiers/functions/value-modifiers which results in a 404.