### PR TITLE
fix: missing hash for links starting with /

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -35,6 +35,7 @@ function relativeURLFix() {
         // any other relative url starting with /
         // NOTE: this does strip off serialized queries and fragments
         newHref += url.pathname.endsWith('/') ? url.pathname : url.pathname + '/';
+        newHref += url.hash || '';
       } else {
         // leave this URL alone
         return;


### PR DESCRIPTION
fixes a regression where hashed links would not work