### PR TITLE
Fix edge case with rehype-urls and trailing slashes in image file paths

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -38,6 +38,7 @@ function relativeURLFix() {
           // append trailing slash to resource only if there is no file extension
           newHref += url.pathname.endsWith('/') ? '' : '/';
         }
+        newHref += url.search || '';
         newHref += url.hash || '';
       } else {
         // leave this URL alone

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -33,8 +33,11 @@ function relativeURLFix() {
         newHref += `/${path}/${url.href}`;
       } else if (url.href.startsWith('/')) {
         // any other relative url starting with /
-        // NOTE: this does strip off serialized queries and fragments
-        newHref += url.pathname.endsWith('/') ? url.pathname : url.pathname + '/';
+        newHref += url.pathname;
+        if (url.pathname.indexOf('.') == -1) {
+          // append trailing slash to resource only if there is no file extension
+          newHref += url.pathname.endsWith('/') ? '' : '/';
+        }
         newHref += url.hash || '';
       } else {
         // leave this URL alone


### PR DESCRIPTION
Yet another https://github.com/tidalcycles/strudel/issues/832 add-on. 🫠

Because of the way Github Pages serves images, it looks like they don't ignore trailing slashes i.e. `https://site.com/image.png` is served but `https://site.com/image.png/` is not. Unfortunately this is different than the localhost server behavior where the slash is ignored so I didn't see this behavior until it went "live."

Thus, the rehype plugin needs to check if the url's resource path has a file extension and make sure not to add a trailing slash if it does. I do this rather primitively by checking if there is a `'.'` anywhere in the url pathname. Seems to work fine. I also added back in the serialized parameter subsection of urls just in case that's needed in the future.