### PR TITLE
Export patterns + ui tweaks

### DIFF
--- a/website/src/repl/Header.jsx
+++ b/website/src/repl/Header.jsx
@@ -87,7 +87,7 @@ export function Header({ context }) {
             )}
           </button>
           <button
-            onClick={handleUpdate}
+            onClick={() => handleUpdate()}
             title="update"
             className={cx(
               'flex items-center space-x-1',

--- a/website/src/repl/panel/PatternsTab.jsx
+++ b/website/src/repl/panel/PatternsTab.jsx
@@ -28,15 +28,15 @@ export function PatternsTab({ context }) {
           <div className="flex items-center mb-2 space-x-2 overflow-auto">
             <h1 className="text-xl">{activePattern}</h1>
             <div className="space-x-4 flex w-min">
-              <button className="hover:opacity-50" onClick={() => duplicateActivePattern()}>
-                <DocumentDuplicateIcon className="w-5 h-5" />
-              </button>
               {!isExample && (
                 <button className="hover:opacity-50" onClick={() => renameActivePattern()}>
                   <PencilSquareIcon className="w-5 h-5" />
                   {/* <PencilIcon className="w-5 h-5" /> */}
                 </button>
               )}
+              <button className="hover:opacity-50" onClick={() => duplicateActivePattern()}>
+                <DocumentDuplicateIcon className="w-5 h-5" />
+              </button>
               {!isExample && (
                 <button className="hover:opacity-50" onClick={() => deleteActivePattern()}>
                   <TrashIcon className="w-5 h-5" />

--- a/website/src/repl/panel/PatternsTab.jsx
+++ b/website/src/repl/panel/PatternsTab.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useMemo } from 'react';
 import * as tunes from '../tunes.mjs';
 import {
   useSettings,
@@ -12,6 +12,7 @@ import {
   addUserPattern,
 } from '../../settings.mjs';
 import { logger } from '@strudel.cycles/core';
+import { DocumentDuplicateIcon, PencilSquareIcon, TrashIcon } from '@heroicons/react/20/solid';
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
@@ -19,10 +20,50 @@ function classNames(...classes) {
 
 export function PatternsTab({ context }) {
   const { userPatterns, activePattern } = useSettings();
+  const isExample = useMemo(() => activePattern && !!tunes[activePattern], [activePattern]);
   return (
     <div className="px-4 w-full dark:text-white text-stone-900 space-y-4 pb-4">
       <section>
-        <div className="px-4 space-x-4 border-b border-foreground mb-2 h-8">
+        {activePattern && (
+          <div className="flex items-center mb-2 space-x-2 overflow-auto">
+            <h1 className="text-xl">{activePattern}</h1>
+            <div className="space-x-4 flex w-min">
+              <button className="hover:opacity-50" onClick={() => duplicateActivePattern()}>
+                <DocumentDuplicateIcon className="w-5 h-5" />
+              </button>
+              {!isExample && (
+                <button className="hover:opacity-50" onClick={() => renameActivePattern()}>
+                  <PencilSquareIcon className="w-5 h-5" />
+                  {/* <PencilIcon className="w-5 h-5" /> */}
+                </button>
+              )}
+              {!isExample && (
+                <button className="hover:opacity-50" onClick={() => deleteActivePattern()}>
+                  <TrashIcon className="w-5 h-5" />
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+        <div className="font-mono text-sm">
+          {Object.entries(userPatterns).map(([key, up]) => (
+            <a
+              key={key}
+              className={classNames(
+                'mr-4 hover:opacity-50 cursor-pointer inline-block',
+                key === activePattern ? 'outline outline-1' : '',
+              )}
+              onClick={() => {
+                const { code } = up;
+                setActivePattern(key);
+                context.handleUpdate(code, true);
+              }}
+            >
+              {key}
+            </a>
+          ))}
+        </div>
+        <div className="pr-4 space-x-4 border-b border-foreground mb-2 h-8 flex overflow-auto max-w-full items-center">
           <button
             className="hover:opacity-50"
             onClick={() => {
@@ -32,15 +73,6 @@ export function PatternsTab({ context }) {
             }}
           >
             new
-          </button>
-          <button className="hover:opacity-50" onClick={() => duplicateActivePattern()}>
-            duplicate
-          </button>
-          <button className="hover:opacity-50" onClick={() => renameActivePattern()}>
-            rename
-          </button>
-          <button className="hover:opacity-50" onClick={() => deleteActivePattern()}>
-            delete
           </button>
           <button className="hover:opacity-50" onClick={() => clearUserPatterns()}>
             clear
@@ -66,24 +98,14 @@ export function PatternsTab({ context }) {
             />
             import
           </label>
-        </div>
-        <div className="font-mono text-sm">
-          {Object.entries(userPatterns).map(([key, up]) => (
-            <a
-              key={key}
-              className={classNames(
-                'mr-4 hover:opacity-50 cursor-pointer inline-block',
-                key === activePattern ? 'outline outline-1' : '',
-              )}
-              onClick={() => {
-                const { code } = up;
-                setActivePattern(key);
-                context.handleUpdate(code, true);
-              }}
-            >
-              {key}
-            </a>
-          ))}
+          <button
+            className="hover:opacity-50"
+            onClick={() => {
+              console.log('export');
+            }}
+          >
+            export
+          </button>
         </div>
       </section>
       <section>

--- a/website/src/repl/panel/PatternsTab.jsx
+++ b/website/src/repl/panel/PatternsTab.jsx
@@ -31,16 +31,16 @@ export function PatternsTab({ context }) {
             <h1 className="text-xl">{activePattern}</h1>
             <div className="space-x-4 flex w-min">
               {!isExample && (
-                <button className="hover:opacity-50" onClick={() => renameActivePattern()}>
+                <button className="hover:opacity-50" onClick={() => renameActivePattern()} title="Rename">
                   <PencilSquareIcon className="w-5 h-5" />
                   {/* <PencilIcon className="w-5 h-5" /> */}
                 </button>
               )}
-              <button className="hover:opacity-50" onClick={() => duplicateActivePattern()}>
+              <button className="hover:opacity-50" onClick={() => duplicateActivePattern()} title="Duplicate">
                 <DocumentDuplicateIcon className="w-5 h-5" />
               </button>
               {!isExample && (
-                <button className="hover:opacity-50" onClick={() => deleteActivePattern()}>
+                <button className="hover:opacity-50" onClick={() => deleteActivePattern()} title="Delete">
                   <TrashIcon className="w-5 h-5" />
                 </button>
               )}

--- a/website/src/settings.mjs
+++ b/website/src/settings.mjs
@@ -81,7 +81,7 @@ export function addUserPattern(name, config) {
     throw new Error('addUserPattern expected code as property of second param');
   }
   const userPatterns = getUserPatterns();
-  setUserPatterns({ ...userPatterns, [name]: config });
+  setUserPatterns({ [name]: config, ...userPatterns });
 }
 
 export function newUserPattern() {
@@ -152,7 +152,7 @@ export function updateUserCode(code) {
     activePattern = getNextCloneName(activePattern);
     setActivePattern(activePattern);
   }
-  setUserPatterns({ ...userPatterns, [activePattern]: { code } });
+  setUserPatterns({ [activePattern]: { code }, ...userPatterns });
 }
 
 export function deleteActivePattern() {
@@ -182,7 +182,7 @@ export function duplicateActivePattern() {
   }
   const userPatterns = getUserPatterns();
   activePattern = getNextCloneName(activePattern);
-  setUserPatterns({ ...userPatterns, [activePattern]: { code: latestCode } });
+  setUserPatterns({ [activePattern]: { code: latestCode }, ...userPatterns });
   setActivePattern(activePattern);
 }
 

--- a/website/src/settings.mjs
+++ b/website/src/settings.mjs
@@ -62,14 +62,14 @@ export const fontSize = patternSetting('fontSize');
 
 export const settingPatterns = { theme, fontFamily, fontSize };
 
-function getUserPatterns() {
+export function getUserPatterns() {
   return JSON.parse(settingsMap.get().userPatterns);
 }
 function getSetting(key) {
   return settingsMap.get()[key];
 }
 
-function setUserPatterns(obj) {
+export function setUserPatterns(obj) {
   settingsMap.setKey('userPatterns', JSON.stringify(obj));
 }
 
@@ -193,3 +193,5 @@ export function duplicateActivePattern() {
 export function setActivePattern(key) {
   settingsMap.setKey('activePattern', key);
 }
+
+export function importUserPatternJSON(jsonString) {}

--- a/website/src/settings.mjs
+++ b/website/src/settings.mjs
@@ -123,6 +123,10 @@ export function renameActivePattern() {
     return;
   }
   const newName = prompt('Enter new name', activePattern);
+  if (newName === null) {
+    // canceled
+    return;
+  }
   if (userPatterns[newName]) {
     alert('Name already taken!');
     return;


### PR DESCRIPTION
all patterns can now be exported as a json file + the import accepts text files (single pattern) or json files (multiple patterns, as exported).

also, some ui tweaks:

- the name of the active pattern is now shown at the top 
- the buttons related to the active pattern have been moved there (edit, duplicate, delete)
- the other buttons are now below the list of user patterns (new, clear, import, export)

<img width="595" alt="image" src="https://github.com/tidalcycles/strudel/assets/12023032/acdd45ed-7462-4835-a83b-35816e1285fc">

below user patterns:

<img width="428" alt="image" src="https://github.com/tidalcycles/strudel/assets/12023032/3a254a93-4737-4a7f-b30c-660deccc3e39">

