### PR TITLE
fix: finally repair envelopes

### DIFF
--- a/packages/soundfonts/fontloader.mjs
+++ b/packages/soundfonts/fontloader.mjs
@@ -139,8 +139,8 @@ export function registerSoundfonts() {
         const { node: envelope, stop: releaseEnvelope } = getEnvelope(attack, decay, sustain, release, 0.3, time);
         bufferSource.connect(envelope);
         const stop = (releaseTime) => {
-          bufferSource.stop(releaseTime + release);
-          releaseEnvelope(releaseTime);
+          const silentAt = releaseEnvelope(releaseTime);
+          bufferSource.stop(silentAt);
         };
         bufferSource.onended = () => {
           bufferSource.disconnect();

--- a/packages/superdough/helpers.mjs
+++ b/packages/superdough/helpers.mjs
@@ -10,21 +10,30 @@ export function gainNode(value) {
 // alternative to getADSR returning the gain node and a stop handle to trigger the release anytime in the future
 export const getEnvelope = (attack, decay, sustain, release, velocity, begin) => {
   const gainNode = getAudioContext().createGain();
+  let phase = begin;
   gainNode.gain.setValueAtTime(0, begin);
-  gainNode.gain.linearRampToValueAtTime(velocity, begin + attack); // attack
-  gainNode.gain.linearRampToValueAtTime(sustain * velocity, begin + attack + decay); // sustain start
+  phase += attack;
+  gainNode.gain.linearRampToValueAtTime(velocity, phase); // attack
+  phase += decay;
+  let sustainLevel = sustain * velocity;
+  gainNode.gain.linearRampToValueAtTime(sustainLevel, phase); // decay / sustain
   // sustain end
   return {
     node: gainNode,
     stop: (t) => {
+      // to make sure the release won't begin before sustain is reached
+      //phase = Math.max(t, phase + 0.001);
+      phase = Math.max(t, phase);
+      // see https://github.com/tidalcycles/strudel/issues/522
       //if (typeof gainNode.gain.cancelAndHoldAtTime === 'function') {
       // gainNode.gain.cancelAndHoldAtTime(t); // this seems to release instantly....
       // see https://discord.com/channels/779427371270275082/937365093082079272/1086053607360712735
       //} else {
       // firefox: this will glitch when the sustain has not been reached yet at the time of release
-      gainNode.gain.setValueAtTime(sustain * velocity, t);
+      gainNode.gain.setValueAtTime(sustainLevel, phase);
       //}
-      gainNode.gain.linearRampToValueAtTime(0, t + release);
+      gainNode.gain.linearRampToValueAtTime(0, phase + release); // release
+      return phase + release;
     },
   };
 };

--- a/packages/superdough/helpers.mjs
+++ b/packages/superdough/helpers.mjs
@@ -22,18 +22,12 @@ export const getEnvelope = (attack, decay, sustain, release, velocity, begin) =>
     node: gainNode,
     stop: (t) => {
       // to make sure the release won't begin before sustain is reached
-      //phase = Math.max(t, phase + 0.001);
       phase = Math.max(t, phase);
       // see https://github.com/tidalcycles/strudel/issues/522
-      //if (typeof gainNode.gain.cancelAndHoldAtTime === 'function') {
-      // gainNode.gain.cancelAndHoldAtTime(t); // this seems to release instantly....
-      // see https://discord.com/channels/779427371270275082/937365093082079272/1086053607360712735
-      //} else {
-      // firefox: this will glitch when the sustain has not been reached yet at the time of release
       gainNode.gain.setValueAtTime(sustainLevel, phase);
-      //}
-      gainNode.gain.linearRampToValueAtTime(0, phase + release); // release
-      return phase + release;
+      phase += release;
+      gainNode.gain.linearRampToValueAtTime(0, phase); // release
+      return phase;
     },
   };
 };

--- a/packages/superdough/sampler.mjs
+++ b/packages/superdough/sampler.mjs
@@ -312,8 +312,8 @@ export async function onTriggerSample(t, value, onended, bank, resolveUrl) {
       const bufferDuration = bufferSource.buffer.duration / bufferSource.playbackRate.value;
       releaseTime = t + (end - begin) * bufferDuration;
     }
-    bufferSource.stop(releaseTime + release);
-    releaseEnvelope(releaseTime);
+    const silentAt = releaseEnvelope(releaseTime);
+    bufferSource.stop(silentAt);
   };
   const handle = { node: out, bufferSource, stop };
 

--- a/packages/superdough/synth.mjs
+++ b/packages/superdough/synth.mjs
@@ -56,10 +56,9 @@ export function registerSynthSounds() {
         return {
           node: o.connect(g).connect(envelope),
           stop: (releaseTime) => {
-            releaseEnvelope(releaseTime);
+            const silentAt = releaseEnvelope(releaseTime);
             triggerRelease?.(releaseTime);
-            let end = releaseTime + release;
-            stop(end);
+            stop(silentAt);
           },
         };
       },


### PR DESCRIPTION
finally found a reasonable fix for https://github.com/tidalcycles/strudel/issues/522 !

Up until now, the release phase was triggered when the event was over. This led to crackles when the sustain level was not yet reached, or in other words: `attack+decay > hap.duration ? crackle() : nocrackle()`

to fix sudden jumps in the envelope, the release now waits for the decay phase to finish, to make sure the automation starts from a value that is actually reached (not creating a sudden jump / crackle).

This is even musically useful, because the envelope can now be used to make the sound longer, even if it exceeds the event duration.

Technically, this is a breaking change, but it will only "break" patterns with crackles, so I guess this is not too bad