### PR TITLE
Bug Fix #119: Clock drift

### DIFF
--- a/packages/core/zyklus.mjs
+++ b/packages/core/zyklus.mjs
@@ -39,6 +39,7 @@ function createClock(
   const pause = () => clear();
   const stop = () => {
     tick = 0;
+    phase = 0;
     clear();
   };
   const getPhase = () => phase;

--- a/packages/core/zyklus.mjs
+++ b/packages/core/zyklus.mjs
@@ -39,7 +39,6 @@ function createClock(
   const pause = () => clear();
   const stop = () => {
     tick = 0;
-    phase = 0;
     clear();
   };
   const getPhase = () => phase;


### PR DESCRIPTION
Updated cyclist based on @yaxu's comment https://github.com/tidalcycles/strudel/issues/119#issuecomment-1743687548 

all cps settings should now stay in time with other music programs/hardware.

clock should no longer accumulate rounding errors
