### PR TITLE
fix: make sure n is never undefined before nanFallback

### DIFF
--- a/packages/core/util.mjs
+++ b/packages/core/util.mjs
@@ -95,7 +95,7 @@ export function nanFallback(value, fallback) {
 }
 // round to nearest int, negative numbers will output a subtracted index
 export const getSoundIndex = (n, numSounds) => {
-  return _mod(Math.round(nanFallback(n, 0)), numSounds);
+  return _mod(Math.round(nanFallback(n ?? 0, 0)), numSounds);
 };
 
 export const getPlayableNoteValue = (hap) => {


### PR DESCRIPTION
when using soundfonts without setting n, the console was spammed with "undefined" is not a number.

this fix makes sure n defaults to 0

follow up for https://github.com/tidalcycles/strudel/pull/871

