### PR TITLE
 bugfix: suspend and close exisiting audio context when changing interface

### DIFF
--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -30,11 +30,12 @@ let audioContext;
 
 export const setDefaultAudioContext = () => {
   audioContext = new AudioContext();
+  return audioContext;
 };
 
 export const getAudioContext = () => {
   if (!audioContext) {
-    setDefaultAudioContext();
+    return setDefaultAudioContext();
   }
   return audioContext;
 };

--- a/website/src/repl/panel/AudioDeviceSelector.jsx
+++ b/website/src/repl/panel/AudioDeviceSelector.jsx
@@ -19,10 +19,14 @@ export const getAudioDevices = async () => {
 };
 
 export const setAudioDevice = async (id) => {
-  const audioCtx = getAudioContext();
+  let audioCtx = getAudioContext();
   if (audioCtx.sinkId === id) {
     return;
   }
+  await audioCtx.suspend();
+  await audioCtx.close();
+  audioCtx = setDefaultAudioContext();
+  await audioCtx.resume();
   const isValidID = (id ?? '').length > 0;
   if (isValidID) {
     try {
@@ -30,9 +34,6 @@ export const setAudioDevice = async (id) => {
     } catch {
       logger('failed to set audio interface', 'warning');
     }
-  } else {
-    // reset the audio context and dont set the sink id if it is invalid AKA System Standard selection
-    setDefaultAudioContext();
   }
   initializeAudioOutput();
 };


### PR DESCRIPTION
@felixroos do you still get that error you mentioned in https://github.com/tidalcycles/strudel/pull/854 with this update? I can't recreate it myself, but I have a hunch this might fix it.