### PR TITLE
support , in < >

### DIFF
--- a/packages/mini/krill-parser.js
+++ b/packages/mini/krill-parser.js
@@ -292,7 +292,7 @@ function peg$parse(input, options) {
   var peg$f3 = function(s) { return s };
   var peg$f4 = function(s, stepsPerCycle) { s.arguments_.stepsPerCycle = stepsPerCycle ; return s; };
   var peg$f5 = function(a) { return a };
-  var peg$f6 = function(s) { s.arguments_.alignment = 'slowcat'; return s; };
+  var peg$f6 = function(s) { s.arguments_.alignment = 'polymeter_slowcat'; return s; };
   var peg$f7 = function(a) { return x => x.options_['weight'] = a };
   var peg$f8 = function(a) { return x => x.options_['reps'] = a };
   var peg$f9 = function(p, s, r) { return x => x.options_['ops'].push({ type_: "bjorklund", arguments_ :{ pulse: p, step:s, rotation:r }}) };
@@ -1073,7 +1073,7 @@ function peg$parse(input, options) {
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parsews();
-      s4 = peg$parsesequence();
+      s4 = peg$parsepolymeter_stack();
       if (s4 !== peg$FAILED) {
         s5 = peg$parsews();
         if (input.charCodeAt(peg$currPos) === 62) {

--- a/packages/mini/krill.pegjs
+++ b/packages/mini/krill.pegjs
@@ -119,8 +119,8 @@ polymeter_steps = "%"a:slice
 
 // define a step-per-cycle timeline e.g <1 3 [3 5]>. We simply defer to a sequence and
 // change the alignment to slowcat
-slow_sequence = ws "<" ws s:sequence ws ">" ws
-  { s.arguments_.alignment = 'slowcat'; return s; }
+slow_sequence = ws "<" ws s:polymeter_stack ws ">" ws
+ { s.arguments_.alignment = 'polymeter_slowcat'; return s; }
 
 // a slice is either a single step or a sub cycle
 slice = step / sub_cycle / polymeter / slow_sequence

--- a/packages/mini/mini.mjs
+++ b/packages/mini/mini.mjs
@@ -91,6 +91,10 @@ export function patternifyAST(ast, code, onEnter, offset = 0) {
       if (alignment === 'stack') {
         return strudel.stack(...children);
       }
+      if (alignment === 'polymeter_slowcat') {
+        const aligned = children.map((child) => child._slow(strudel.Fraction(child.__weight ?? 1)));
+        return strudel.stack(...aligned);
+      }
       if (alignment === 'polymeter') {
         // polymeter
         const stepsPerCycle = ast.arguments_.stepsPerCycle
@@ -104,15 +108,9 @@ export function patternifyAST(ast, code, onEnter, offset = 0) {
         return strudel.chooseInWith(strudel.rand.early(randOffset * ast.arguments_.seed).segment(1), children);
       }
       const weightedChildren = ast.source_.some((child) => !!child.options_?.weight);
-      if (!weightedChildren && alignment === 'slowcat') {
-        return strudel.slowcat(...children);
-      }
       if (weightedChildren) {
         const weightSum = ast.source_.reduce((sum, child) => sum + (child.options_?.weight || 1), 0);
         const pat = strudel.timeCat(...ast.source_.map((child, i) => [child.options_?.weight || 1, children[i]]));
-        if (alignment === 'slowcat') {
-          return pat._slow(weightSum); // timecat + slow
-        }
         pat.__weight = weightSum;
         return pat;
       }


### PR DESCRIPTION
changes the mini parser slightly to support "," inside "< ... >", which allows using them for polymeters.
These two are now equivalent:

```js
s("<bd rim, hh hh oh>*2")
s("{bd rim, hh hh oh}%2")
```

iirc this is also how it works in tidal (have to recheck)