### PR TITLE
fix: codemirror does not vanish anymore on hot reload

### DIFF
--- a/packages/codemirror/codemirror.mjs
+++ b/packages/codemirror/codemirror.mjs
@@ -323,6 +323,7 @@ export class StrudelMirror {
     this.editor.dispatch({ changes });
   }
   clear() {
+    this.stop();
     this.onStartRepl && document.removeEventListener('start-repl', this.onStartRepl);
   }
 }

--- a/website/src/repl/Repl.jsx
+++ b/website/src/repl/Repl.jsx
@@ -100,6 +100,16 @@ export function Repl({ embedded = false }) {
     });
 
     editorRef.current = editor;
+
+    if (import.meta.hot) {
+      import.meta.hot.dispose(() => {
+        editorRef.current.clear();
+        setTimeout(() => {
+          delete editorRef.current;
+          delete containerRef.current;
+        });
+      });
+    }
   }, []);
 
   const [replState, setReplState] = useState({});
@@ -199,7 +209,7 @@ export function Repl({ embedded = false }) {
             id="code"
             ref={(el) => {
               containerRef.current = el;
-              if (!editorRef.current) {
+              if (!editorRef.current && containerRef.current) {
                 init();
               }
             }}


### PR DESCRIPTION
when saving certain files, for example superdough.mjs, the codemirror editor would just vanish.
It seems the hot reloading clears the #code element (Repl.jsx) without deleting the refs, so init won't be called again. 
Luckily, there is an API for vite to hook into hot reloading life cycle: https://vitejs.dev/guide/api-hmr#hot-dispose-cb

I managed to at least clear the refs and stop the previous repl, so it will be recreated when the #code ref fires again.
I am not sure if it's even possible to hot swap the editor without loosing the context. maybe it is but maybe it's not worth the hassle. @daslyfe any idea? how is this related to https://github.com/tidalcycles/strudel/pull/892 ?