### PR TITLE
add pregain + move postgain after sends

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -87,7 +87,12 @@ const generic_params = [
    */
   ['gain'],
   /**
-   * Gain applied after all effects have been processed.
+   * Gain applied before effect sends (delay, reverb ...)
+   *
+   */
+  ['pregain'],
+  /**
+   * Gain applied after effect sends (delay, reverb ...)
    *
    * @name postgain
    * @example


### PR DESCRIPTION
the `postgain` control was a bit misleading, as it was still applied before the effect sends. this PR adds another gain stage called `pregain` be the gain stage before the effect sends (but after local effects). Additionally, if a value is set to `postgain`, another gain stage will be added at the very end. this should allow full wet effects in the future. The signal path is now:

source -> gain -> local fx -> pregain -> sends -> postgain