### PR TITLE
Fix: swatch/[name].png.js static path

### DIFF
--- a/website/src/pages/swatch/[name].png.js
+++ b/website/src/pages/swatch/[name].png.js
@@ -14,10 +14,7 @@ export async function GET({ params, request }) {
   const ctx = canvas.getContext('2d');
   pianoroll({ time: 4, haps, ctx, playhead: 1, fold: 1, background: 'transparent', playheadColor: 'transparent' });
   const buffer = canvas.toBuffer('image/png');
-  return {
-    body: buffer,
-    encoding: 'binary',
-  };
+  return new Response(buffer);
 }
 export async function getStaticPaths() {
   const patterns = await getMyPatterns();


### PR DESCRIPTION
When using the `my-patterns` feature the build fails to build static routes for `src/pages/swatch/[name].png.js`. Switching to Astro's new(?) `Response` class fixes this

Failing build: https://github.com/oscarbyrne/strudel/actions/runs/7548040318/job/20549292374
Passing build: https://github.com/oscarbyrne/strudel/actions/runs/7563947791/job/20597262748