### PR TITLE
Refactor cps functions

### DIFF
--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -427,7 +427,7 @@ export class Pattern {
    * @noAutocomplete
    */
   withHaps(func) {
-    return new Pattern((state) => func(this.query(state)));
+    return new Pattern((state) => func(this.query(state), state));
   }
 
   /**
@@ -2377,12 +2377,14 @@ export const { loopAt, loopat } = register(['loopAt', 'loopat'], function (facto
  * s("rhodes/4").fit()
  */
 export const fit = register('fit', (pat) =>
-  pat.withHap((hap) =>
-    hap.withValue((v) => ({
-      ...v,
-      speed: 1 / hap.whole.duration,
-      unit: 'c',
-    })),
+  pat.withHaps((haps, state) =>
+    haps.map((hap) =>
+      hap.withValue((v) => ({
+        ...v,
+        speed: (state.controls._cps || 1) / hap.whole.duration,
+        unit: 'c',
+      })),
+    ),
   ),
 );
 

--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -2359,15 +2359,10 @@ export const splice = register(
   false, // turns off auto-patternification
 );
 
-// this function will be redefined in repl.mjs to use the correct cps value.
-// It is still here to work in cases where repl.mjs is not used
-
 export const { loopAt, loopat } = register(['loopAt', 'loopat'], function (factor, pat) {
-  return _loopAt(factor, pat, 1);
+  return new Pattern((state) => _loopAt(factor, pat, state.controls._cps).query(state));
 });
 
-// the fit function will be redefined in repl.mjs to use the correct cps value.
-// It is still here to work in cases where repl.mjs is not used
 /**
  * Makes the sample fit its event duration. Good for rhythmical loops like drum breaks.
  * Similar to `loopAt`.

--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -68,18 +68,18 @@ export function repl({
   const toggle = () => scheduler.toggle();
   const setCps = (cps) => scheduler.setCps(cps);
   const setCpm = (cpm) => scheduler.setCps(cpm / 60);
+  const all = function (transform) {
+    allTransform = transform;
+    return silence;
+  };
 
+  // set pattern methods that use this repl via closure
   const injectPatternMethods = () => {
     Pattern.prototype.p = function (id) {
       pPatterns[id] = this;
       return this;
     };
     Pattern.prototype.q = function (id) {
-      return silence;
-    };
-
-    const all = function (transform) {
-      allTransform = transform;
       return silence;
     };
     try {
@@ -101,7 +101,6 @@ export function repl({
     } catch (err) {
       console.warn('injectPatternMethods: error:', err);
     }
-
     evalScope({
       all,
       hush,

--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -142,19 +142,8 @@ export function repl({
     // already defined..
   }
 
-  const fit = register('fit', (pat) =>
-    pat.withHap((hap) =>
-      hap.withValue((v) => ({
-        ...v,
-        speed: scheduler.cps / hap.whole.duration, // overwrite speed completely?
-        unit: 'c',
-      })),
-    ),
-  );
-
   evalScope({
     loopAt,
-    fit,
     all,
     hush,
     setCps,

--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -107,11 +107,6 @@ export function repl({
   const setCps = (cps) => scheduler.setCps(cps);
   const setCpm = (cpm) => scheduler.setCps(cpm / 60);
 
-  // the following functions use the cps value, which is why they are defined here..
-  const loopAt = register('loopAt', (cycles, pat) => {
-    return pat.loopAtCps(cycles, scheduler.cps);
-  });
-
   Pattern.prototype.p = function (id) {
     pPatterns[id] = this;
     return this;
@@ -143,7 +138,6 @@ export function repl({
   }
 
   evalScope({
-    loopAt,
     all,
     hush,
     setCps,

--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -88,16 +88,18 @@ export function repl({
           get() {
             return this.p(i);
           },
+          configurable: true,
         });
         Object.defineProperty(Pattern.prototype, `p${i}`, {
           get() {
             return this.p(i);
           },
+          configurable: true,
         });
         Pattern.prototype[`q${i}`] = silence;
       }
     } catch (err) {
-      // already defined..
+      console.warn('injectPatternMethods: error:', err);
     }
 
     evalScope({

--- a/website/src/components/Oven/Oven.jsx
+++ b/website/src/components/Oven/Oven.jsx
@@ -6,6 +6,7 @@ import { PatternLabel } from '@src/repl/panel/PatternsTab';
 function PatternList({ patterns }) {
   return (
     <div className="space-y-4">
+      {/* <MiniRepl tunes={patterns.map((pat) => pat.code.trim())} /> */}
       {patterns.map((pat) => (
         <div key={pat.id}>
           <div className="flex justify-between not-prose pb-2">
@@ -15,8 +16,7 @@ function PatternList({ patterns }) {
               </a>
             </h2>
           </div>
-          {/* <MiniRepl tune={pat.code.trim()} /> */}
-          {/* <pre>{JSON.stringify(pat)}</pre> */}
+          <MiniRepl tune={pat.code.trim()} maxHeight={300} />
         </div>
       ))}
     </div>

--- a/website/src/docs/MiniRepl.jsx
+++ b/website/src/docs/MiniRepl.jsx
@@ -27,6 +27,7 @@ export function MiniRepl({
   punchcardLabels = true,
   claviature,
   claviatureLabels,
+  maxHeight,
 }) {
   const code = tunes ? tunes[0] : tune;
   const id = useMemo(() => s4(), []);
@@ -154,7 +155,7 @@ export function MiniRepl({
           )}
         </div>
       )}
-      <div className="overflow-auto relative p-1">
+      <div className="overflow-auto relative p-1" style={maxHeight ? { maxHeight: `${maxHeight}px` } : {}}>
         <div
           ref={(el) => {
             if (!editorRef.current) {


### PR DESCRIPTION
following https://github.com/tidalcycles/strudel/pull/932 , the remaining functions that depend on scheduler cps ( `fit` / `loopAt` ) are now receiving the cps through pattern state, which gets the cps from the scheduler at query time.

Additionally, the functions that interact with the scheduler ( `all` , `hush` , `setcps` , `setcpm` ) did not work with multiple repls on the same page, because the last repl that was initialized got to set those functions on the eval scope. so any of those functions running in another repl would interact only with the last loaded scheduler. i fixed this by setting the functions on the eval scope right before evaluation, to make sure the Pattern is talking to the correct scheduler. This still feels a bit hacky, but it should work reliably (as long as 2 repls are not evaluated simultaneously)

this fixes the most annoying part of https://github.com/tidalcycles/strudel/issues/922 so I've also now added mini repls to the community bakery