### PR TITLE
fix midi issue on firefox and added quote error

### DIFF
--- a/packages/midi/midi.mjs
+++ b/packages/midi/midi.mjs
@@ -167,10 +167,16 @@ let listeners = {};
 const refs = {};
 
 export async function midin(input) {
+  if (isPattern(input)) {
+    throw new Error(
+      `.midi does not accept Pattern input. Make sure to pass device name with single quotes. Example: .midi('${
+        WebMidi.outputs?.[0]?.name || 'IAC Driver Bus 1'
+      }')`,
+    );
+  }
   const initial = await enableWebMidi(); // only returns on first init
   const device = getDevice(input, WebMidi.inputs);
-
-  if (initial) {
+  if (initial || WebMidi.enabled) {
     const otherInputs = WebMidi.inputs.filter((o) => o.name !== device.name);
     logger(
       `Midi enabled! Using "${device.name}". ${


### PR DESCRIPTION
Fixed this error that happens on firefox 
```
[query]: can't access property 72, refs[input] is undefined
```
And added an error when you use double quotes on the midi device name. 

There is still a problem with the `WebMidi.enable()` function that never stops loading.  