### PR TITLE
Minor documentation error: Update first-sounds.mdx

### DIFF
--- a/website/src/pages/workshop/first-sounds.mdx
+++ b/website/src/pages/workshop/first-sounds.mdx
@@ -139,7 +139,7 @@ The content of a sequence will be squished into what's called a cycle.
 
 cpm = cycles per minute
 
-By default, the tempo is 60 cycles per minute = 1 cycle per second.
+By default, the tempo is 30 cycles per minute = 1 half cycle per second.
 
 </Box>
 


### PR DESCRIPTION
Update the tutorial text to reflect that the default cpm setting has changed from 60 to 30.