### PR TITLE
pickr and solo with stacking info

### DIFF
--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -3,7 +3,7 @@ import { evaluate as _evaluate } from './evaluate.mjs';
 import { logger } from './logger.mjs';
 import { setTime } from './time.mjs';
 import { evalScope } from './evaluate.mjs';
-import { register, Pattern, isPattern, silence, stack } from './pattern.mjs';
+import { register, Pattern, isPattern, silence, oldstack } from './pattern.mjs';
 
 export function repl({
   interval,
@@ -126,7 +126,7 @@ export function repl({
       shouldHush && hush();
       let { pattern, meta } = await _evaluate(code, transpiler);
       if (Object.keys(pPatterns).length) {
-        pattern = stack(...Object.values(pPatterns));
+        pattern = oldstack(...Object.values(pPatterns));
       }
       if (allTransform) {
         pattern = allTransform(pattern);

--- a/packages/mini/mini.mjs
+++ b/packages/mini/mini.mjs
@@ -93,7 +93,7 @@ export function patternifyAST(ast, code, onEnter, offset = 0) {
       }
       if (alignment === 'polymeter_slowcat') {
         const aligned = children.map((child) => child._slow(strudel.Fraction(child.__weight ?? 1)));
-        return strudel.stack(...aligned);
+        return strudel.oldstack(...aligned);
       }
       if (alignment === 'polymeter') {
         // polymeter
@@ -102,7 +102,7 @@ export function patternifyAST(ast, code, onEnter, offset = 0) {
           : strudel.pure(strudel.Fraction(children.length > 0 ? children[0].__weight : 1));
 
         const aligned = children.map((child) => child.fast(stepsPerCycle.fmap((x) => x.div(child.__weight || 1))));
-        return strudel.stack(...aligned);
+        return strudel.oldstack(...aligned);
       }
       if (alignment === 'rand') {
         return strudel.chooseInWith(strudel.rand.early(randOffset * ast.arguments_.seed).segment(1), children);


### PR DESCRIPTION
Now stack()  (and the mininotation comma operator) populate the 'stacking' property of the hap context by pushing the stacking index into an array. The array handles nested stacking also. The outermost stacking level is the first element of the array.

The new solo() and mute() functions make use of this information by keeping only the haps that match (or not) the specified outermost stacking index. The new produced haps also have this index striped out from the stacking array, so subsequent calls of solo() can work with the inner stacking layers.

The implementation of solo() may be a little tricky. The original hap value is temporarily stored in context.tempvalue, modified to the stacking index, and then restored after the filtering operation is done.

The new pickr() and pickrmod() functions make use of solo(0), because restart("[1,2]") produces a pattern with duplicated haps. "[1,2]".solo(0) should be equivalent to "[1]", thus solving the problem.

I have also fixed two little typos in inhabit() and inhabitmod() declarations.
