### PR TITLE
pickOut(), pickRestart(), pickReset()

### DIFF
--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -304,6 +304,8 @@ export const pickmodReset = register('pickmodReset', function (lookup, pat) {
 /**
 /** * Picks patterns (or plain values) either from a list (by index) or a lookup table (by name).
  * Similar to `pick`, but cycles are squeezed into the target ('inhabited') pattern.
+ * @name inhabit
+ * @synonyms pickSqueeze
  * @param {Pattern} pat
  * @param {*} xs
  * @returns {Pattern}
@@ -322,6 +324,8 @@ export const { inhabit, pickSqueeze } = register(['inhabit', 'pickSqueeze'], fun
  * it wraps around, rather than sticking at the maximum value.
  * For example, if you pick the fifth pattern of a list of three, you'll get the
  * second one.
+ * @name inhabitmod
+ * @synonyms pickmodSqueeze
  * @param {Pattern} pat
  * @param {*} xs
  * @returns {Pattern}

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -249,17 +249,17 @@ export const pickmodF = register('pickmodF', function (lookup, funcs, pat) {
  * @param {*} xs
  * @returns {Pattern}
  */
-export const pickOuter = register('pickOuter', function (lookup, pat) {
+export const pickOut = register('pickOut', function (lookup, pat) {
   return _pick(lookup, pat, false).outerJoin();
 });
 
-/** * The same as `pickOuter`, but if you pick a number greater than the size of the list,
+/** * The same as `pickOut`, but if you pick a number greater than the size of the list,
  * it wraps around, rather than sticking at the maximum value.
  * @param {Pattern} pat
  * @param {*} xs
  * @returns {Pattern}
  */
-export const pickmodOuter = register('pickmodOuter', function (lookup, pat) {
+export const pickmodOut = register('pickmodOut', function (lookup, pat) {
   return _pick(lookup, pat, true).outerJoin();
 });
 
@@ -314,7 +314,7 @@ export const pickmodReset = register('pickmodReset', function (lookup, pat) {
  * @example
  * s("a@2 [a b] a".inhabit({a: "bd(3,8)", b: "sd sd"})).slow(4)
  */
-export const inhabit = register('inhabit', function (lookup, pat) {
+export const { inhabit, pickSqueeze } = register(['inhabit', 'pickSqueeze'], function (lookup, pat) {
   return _pick(lookup, pat, false).squeezeJoin();
 });
 
@@ -327,7 +327,7 @@ export const inhabit = register('inhabit', function (lookup, pat) {
  * @returns {Pattern}
  */
 
-export const inhabitmod = register('inhabitmod', function (lookup, pat) {
+export const { inhabitmod, pickmodSqueeze } = register(['inhabitmod', 'pickmodSqueeze'], function (lookup, pat) {
   return _pick(lookup, pat, true).squeezeJoin();
 });
 

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -253,7 +253,7 @@ export const pickRestart = register('pickRestart', function (lookup, pat) {
   return _pick(lookup, pat, false).trigzeroJoin();
 });
 
-/** * The same as `pickr`, but if you pick a number greater than the size of the list,
+/** * The same as `pickRestart`, but if you pick a number greater than the size of the list,
  * it wraps around, rather than sticking at the maximum value.
  * @param {Pattern} pat
  * @param {*} xs
@@ -272,7 +272,7 @@ export const pickReset = register('pickReset', function (lookup, pat) {
   return _pick(lookup, pat, false).trigJoin();
 });
 
-/** * The same as `pickr`, but if you pick a number greater than the size of the list,
+/** * The same as `pickReset`, but if you pick a number greater than the size of the list,
  * it wraps around, rather than sticking at the maximum value.
  * @param {Pattern} pat
  * @param {*} xs

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -244,6 +244,25 @@ export const pickmodF = register('pickmodF', function (lookup, funcs, pat) {
   return pat.apply(pickmod(lookup, funcs));
 });
 
+/** * Similar to `pick`, but it applies an outerJoin instead of an innerJoin.
+ * @param {Pattern} pat
+ * @param {*} xs
+ * @returns {Pattern}
+ */
+export const pickOuter = register('pickOuter', function (lookup, pat) {
+  return _pick(lookup, pat, false).outerJoin();
+});
+
+/** * The same as `pickRestart`, but if you pick a number greater than the size of the list,
+ * it wraps around, rather than sticking at the maximum value.
+ * @param {Pattern} pat
+ * @param {*} xs
+ * @returns {Pattern}
+ */
+export const pickmodOuter = register('pickmodOuter', function (lookup, pat) {
+  return _pick(lookup, pat, true).outerJoin();
+});
+
 /** * Similar to `pick`, but the choosen pattern is restarted when its index is triggered.
  * @param {Pattern} pat
  * @param {*} xs

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -253,7 +253,7 @@ export const pickOuter = register('pickOuter', function (lookup, pat) {
   return _pick(lookup, pat, false).outerJoin();
 });
 
-/** * The same as `pickRestart`, but if you pick a number greater than the size of the list,
+/** * The same as `pickOuter`, but if you pick a number greater than the size of the list,
  * it wraps around, rather than sticking at the maximum value.
  * @param {Pattern} pat
  * @param {*} xs

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -160,7 +160,7 @@ export const _irand = (i) => rand.fmap((x) => Math.trunc(x * i));
  */
 export const irand = (ipat) => reify(ipat).fmap(_irand).innerJoin();
 
-const _pick = function (lookup, pat, modulo = true, restart = false) {
+const _pick = function (lookup, pat, modulo = true) {
   const array = Array.isArray(lookup);
   const len = Object.keys(lookup).length;
 
@@ -174,7 +174,7 @@ const _pick = function (lookup, pat, modulo = true, restart = false) {
     if (array) {
       key = modulo ? Math.round(key) % len : clamp(Math.round(key), 0, lookup.length - 1);
     }
-    return restart ? lookup[key].restart(pat.collect().fmap((v) => v + 1)) : lookup[key];
+    return lookup[key];
   });
 };
 
@@ -244,14 +244,13 @@ export const pickmodF = register('pickmodF', function (lookup, funcs, pat) {
   return pat.apply(pickmod(lookup, funcs));
 });
 
-/** * Similar to `pick`, but restart() is invoked everytime a new index is triggered.
- * In case of stacked indexes, collect() function is used to avoid multiple restarting triggers
+/** * Similar to `pick`, but the choosen pattern is restarted when its index is triggered.
  * @param {Pattern} pat
  * @param {*} xs
  * @returns {Pattern}
  */
 export const pickr = register('pickr', function (lookup, pat) {
-  return _pick(lookup, pat, false, true).innerJoin();
+  return _pick(lookup, pat, false).trigzeroJoin();
 });
 
 /** * The same as `pickr`, but if you pick a number greater than the size of the list,
@@ -263,7 +262,7 @@ export const pickr = register('pickr', function (lookup, pat) {
  * @returns {Pattern}
  */
 export const pickrmod = register('pickrmod', function (lookup, pat) {
-  return _pick(lookup, pat, true, true).innerJoin();
+  return _pick(lookup, pat, true).trigzeroJoin();
 });
 
 /**

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -253,7 +253,11 @@ export const pickmodF = register('pickmodF', function (lookup, funcs, pat) {
  * @returns {Pattern}
  */
 export const pickr = register('pickr', function (lookup, pat) {
-  return _pick(lookup.map((x)=>x.restart(pat.collect().fmap(v=>v+1))), pat, false).innerJoin();
+  return _pick(
+    lookup.map((x) => x.restart(pat.collect().fmap((v) => v + 1))),
+    pat,
+    false,
+  ).innerJoin();
 });
 
 /** * The same as `pickr`, but if you pick a number greater than the size of the list,
@@ -265,7 +269,11 @@ export const pickr = register('pickr', function (lookup, pat) {
  * @returns {Pattern}
  */
 export const pickrmod = register('pickrmod', function (lookup, pat) {
-  return _pick(lookup.map((x)=>x.restart(pat.collect().fmap(v=>v+1))), pat, true).innerJoin();
+  return _pick(
+    lookup.map((x) => x.restart(pat.collect().fmap((v) => v + 1))),
+    pat,
+    true,
+  ).innerJoin();
 });
 
 /**

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -160,7 +160,7 @@ export const _irand = (i) => rand.fmap((x) => Math.trunc(x * i));
  */
 export const irand = (ipat) => reify(ipat).fmap(_irand).innerJoin();
 
-const _pick = function (lookup, pat, modulo = true) {
+const _pick = function (lookup, pat, modulo = true, restart = false) {
   const array = Array.isArray(lookup);
   const len = Object.keys(lookup).length;
 
@@ -174,7 +174,7 @@ const _pick = function (lookup, pat, modulo = true) {
     if (array) {
       key = modulo ? Math.round(key) % len : clamp(Math.round(key), 0, lookup.length - 1);
     }
-    return lookup[key];
+    return restart ? lookup[key].restart(pat.collect().fmap((v) => v + 1)) : lookup[key];
   });
 };
 
@@ -251,11 +251,7 @@ export const pickmodF = register('pickmodF', function (lookup, funcs, pat) {
  * @returns {Pattern}
  */
 export const pickr = register('pickr', function (lookup, pat) {
-  return _pick(
-    lookup.map((x) => x.restart(pat.collect().fmap((v) => v + 1))),
-    pat,
-    false,
-  ).innerJoin();
+  return _pick(lookup, pat, false, true).innerJoin();
 });
 
 /** * The same as `pickr`, but if you pick a number greater than the size of the list,
@@ -267,11 +263,7 @@ export const pickr = register('pickr', function (lookup, pat) {
  * @returns {Pattern}
  */
 export const pickrmod = register('pickrmod', function (lookup, pat) {
-  return _pick(
-    lookup.map((x) => x.restart(pat.collect().fmap((v) => v + 1))),
-    pat,
-    true,
-  ).innerJoin();
+  return _pick(lookup, pat, true, true).innerJoin();
 });
 
 /**

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -246,6 +246,30 @@ export const pickmodF = register('pickmodF', function (lookup, funcs, pat) {
 
 /**
 /** * Picks patterns (or plain values) either from a list (by index) or a lookup table (by name).
+ * Similar to `pick`, but restart() is invoked everytime a new index is triggered.
+ * In case of stacked indexes, collect() function is used to avoid multiple restarting triggers
+ * @param {Pattern} pat
+ * @param {*} xs
+ * @returns {Pattern}
+ */
+export const pickr = register('pickr', function (lookup, pat) {
+  return _pick(lookup.map((x)=>x.restart(pat.collect().fmap(v=>v+1))), pat, false).innerJoin();
+});
+
+/** * The same as `pickr`, but if you pick a number greater than the size of the list,
+ * it wraps around, rather than sticking at the maximum value.
+ * For example, if you pick the fifth pattern of a list of three, you'll get the
+ * second one.
+ * @param {Pattern} pat
+ * @param {*} xs
+ * @returns {Pattern}
+ */
+export const pickrmod = register('pickrmod', function (lookup, pat) {
+  return _pick(lookup.map((x)=>x.restart(pat.collect().fmap(v=>v+1))), pat, true).innerJoin();
+});
+
+/**
+/** * Picks patterns (or plain values) either from a list (by index) or a lookup table (by name).
  * Similar to `pick`, but cycles are squeezed into the target ('inhabited') pattern.
  * @param {Pattern} pat
  * @param {*} xs
@@ -258,7 +282,7 @@ export const pickmodF = register('pickmodF', function (lookup, funcs, pat) {
  * s("a@2 [a b] a".inhabit({a: "bd(3,8)", b: "sd sd"})).slow(4)
  */
 export const inhabit = register('inhabit', function (lookup, pat) {
-  return _pick(lookup, pat, true).squeezeJoin();
+  return _pick(lookup, pat, false).squeezeJoin();
 });
 
 /** * The same as `inhabit`, but if you pick a number greater than the size of the list,
@@ -270,8 +294,8 @@ export const inhabit = register('inhabit', function (lookup, pat) {
  * @returns {Pattern}
  */
 
-export const inhabitmod = register('inhabit', function (lookup, pat) {
-  return _pick(lookup, pat, false).squeezeJoin();
+export const inhabitmod = register('inhabitmod', function (lookup, pat) {
+  return _pick(lookup, pat, true).squeezeJoin();
 });
 
 /**

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -249,20 +249,37 @@ export const pickmodF = register('pickmodF', function (lookup, funcs, pat) {
  * @param {*} xs
  * @returns {Pattern}
  */
-export const pickr = register('pickr', function (lookup, pat) {
+export const pickRestart = register('pickRestart', function (lookup, pat) {
   return _pick(lookup, pat, false).trigzeroJoin();
 });
 
 /** * The same as `pickr`, but if you pick a number greater than the size of the list,
  * it wraps around, rather than sticking at the maximum value.
- * For example, if you pick the fifth pattern of a list of three, you'll get the
- * second one.
  * @param {Pattern} pat
  * @param {*} xs
  * @returns {Pattern}
  */
-export const pickrmod = register('pickrmod', function (lookup, pat) {
+export const pickmodRestart = register('pickmodRestart', function (lookup, pat) {
   return _pick(lookup, pat, true).trigzeroJoin();
+});
+
+/** * Similar to `pick`, but the choosen pattern is reset when its index is triggered.
+ * @param {Pattern} pat
+ * @param {*} xs
+ * @returns {Pattern}
+ */
+export const pickReset = register('pickReset', function (lookup, pat) {
+  return _pick(lookup, pat, false).trigJoin();
+});
+
+/** * The same as `pickr`, but if you pick a number greater than the size of the list,
+ * it wraps around, rather than sticking at the maximum value.
+ * @param {Pattern} pat
+ * @param {*} xs
+ * @returns {Pattern}
+ */
+export const pickmodReset = register('pickmodReset', function (lookup, pat) {
+  return _pick(lookup, pat, true).trigJoin();
 });
 
 /**

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -244,9 +244,7 @@ export const pickmodF = register('pickmodF', function (lookup, funcs, pat) {
   return pat.apply(pickmod(lookup, funcs));
 });
 
-/**
-/** * Picks patterns (or plain values) either from a list (by index) or a lookup table (by name).
- * Similar to `pick`, but restart() is invoked everytime a new index is triggered.
+/** * Similar to `pick`, but restart() is invoked everytime a new index is triggered.
  * In case of stacked indexes, collect() function is used to avoid multiple restarting triggers
  * @param {Pattern} pat
  * @param {*} xs


### PR DESCRIPTION
added pickr() and pickrmod() , see https://github.com/tidalcycles/strudel/issues/948

also fixed typos in inhabit() and inhabitmod()
