### PR TITLE
fix script importable packages (web + repl)

### DIFF
--- a/examples/buildless/web-component-no-iframe.html
+++ b/examples/buildless/web-component-no-iframe.html
@@ -1,4 +1,4 @@
-<script src="https://unpkg.com/@strudel/repl@0.9.4"></script>
+<script src="https://unpkg.com/@strudel/repl@1.0.2"></script>
 <strudel-editor>
   <!--
 // @date 23-08-15

--- a/examples/buildless/web.html
+++ b/examples/buildless/web.html
@@ -1,0 +1,9 @@
+<script src="https://unpkg.com/@strudel/web@1.0.2/dist/index.js"></script>
+<button id="play">PLAY</button>
+<script>
+  initStrudel({
+    prebake: () => samples('github:tidalcycles/dirt-samples'),
+  });
+
+  document.getElementById('play').addEventListener('click', () => s('bd sd').play());
+</script>

--- a/examples/buildless/web.html
+++ b/examples/buildless/web.html
@@ -1,9 +1,8 @@
-<script src="https://unpkg.com/@strudel/web@1.0.2/dist/index.js"></script>
+<script src="https://unpkg.com/@strudel/web@1.0.3"></script>
 <button id="play">PLAY</button>
 <script>
   initStrudel({
     prebake: () => samples('github:tidalcycles/dirt-samples'),
   });
-
   document.getElementById('play').addEventListener('click', () => s('bd sd').play());
 </script>

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@strudel/repl",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Strudel REPL as a Web Component",
-  "main": "index.mjs",
+  "module": "index.mjs",
   "publishConfig": {
-    "main": "dist/index.mjs"
+    "main": "dist/index.js",
+    "module": "dist/index.mjs"
   },
   "scripts": {
     "build": "vite build",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,7 +36,8 @@
     "@strudel/mini": "workspace:*",
     "@strudel/tonal": "workspace:*",
     "@strudel/transpiler": "workspace:*",
-    "@strudel/webaudio": "workspace:*"
+    "@strudel/webaudio": "workspace:*",
+    "@rollup/plugin-replace": "^5.0.5"
   },
   "devDependencies": {
     "vite": "^5.0.10"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@strudel/web",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Easy to setup, opiniated bundle of Strudel for the browser.",
-  "main": "web.mjs",
+  "module": "web.mjs",
   "publishConfig": {
-    "main": "dist/index.mjs"
+    "main": "dist/index.js",
+    "module": "dist/index.mjs"
   },
   "scripts": {
     "build": "vite build",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strudel/web",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Easy to setup, opiniated bundle of Strudel for the browser.",
   "main": "web.mjs",
   "publishConfig": {

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import { dependencies } from './package.json';
 import { resolve } from 'path';
+import replace from '@rollup/plugin-replace';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -8,11 +9,18 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'web.mjs'),
-      formats: ['es'],
-      fileName: (ext) => ({ es: 'index.mjs' })[ext],
+      name: 'strudel',
+      formats: ['es', 'iife'],
+      fileName: (ext) => ({ es: 'index.mjs', iife: 'index.js' })[ext],
     },
     rollupOptions: {
-      external: [...Object.keys(dependencies)],
+      // external: [...Object.keys(dependencies)],
+      plugins: [
+        replace({
+          'process.env.NODE_ENV': JSON.stringify('production'),
+          preventAssignment: true,
+        }),
+      ],
     },
     target: 'esnext',
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,6 +430,9 @@ importers:
 
   packages/web:
     dependencies:
+      '@rollup/plugin-replace':
+        specifier: ^5.0.5
+        version: 5.0.5
       '@strudel/core':
         specifier: workspace:*
         version: link:../core
@@ -3691,7 +3694,6 @@ packages:
     dependencies:
       '@rollup/pluginutils': 5.1.0
       magic-string: 0.30.5
-    dev: true
 
   /@rollup/pluginutils@3.1.0(rollup@2.79.1):
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
@@ -3717,7 +3719,6 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-    dev: true
 
   /@rollup/rollup-android-arm-eabi@4.9.2:
     resolution: {integrity: sha512-RKzxFxBHq9ysZ83fn8Iduv3A283K7zPPYuhL/z9CQuyFrjwpErJx0h4aeb/bnJ+q29GRLgJpY66ceQ/Wcsn3wA==}
@@ -7118,7 +7119,6 @@ packages:
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: true
 
   /estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}


### PR DESCRIPTION
fixes the packages `@strudel/web` and `@strudel/repl` to be importable via script tag by setting the `main` field to the `iife` build.