### PR TITLE
feat: can now invert euclid pulses with negative numbers

### DIFF
--- a/packages/core/euclid.mjs
+++ b/packages/core/euclid.mjs
@@ -41,11 +41,17 @@ const _bjork = function (n, x) {
 };
 
 export const bjork = function (ons, steps) {
+  const inverted = ons < 0;
+  ons = Math.abs(ons);
   const offs = steps - ons;
   const x = Array(ons).fill([1]);
   const y = Array(offs).fill([0]);
   const result = _bjork([ons, offs], [x, y]);
-  return flatten(result[1][0]).concat(flatten(result[1][1]));
+  const p = flatten(result[1][0]).concat(flatten(result[1][1]));
+  if (inverted) {
+    return p.map((x) => (x === 0 ? 1 : 0));
+  }
+  return p;
 };
 
 /**


### PR DESCRIPTION
the `bjork` function now inverts the output if the first param is negative. this is useful to create pairs of euclid patterns that fill each others gaps:

```js
s("bd(3,8), hh(-3,8)")
```

iirc tidal also has this feature