### PR TITLE
fix for transpose(): preserve hap value object structure

### DIFF
--- a/packages/tonal/tonal.mjs
+++ b/packages/tonal/tonal.mjs
@@ -103,6 +103,8 @@ export const transpose = register('transpose', function (intervalOrSemitones, pa
       const semitones = typeof interval === 'string' ? Interval.semitones(interval) || 0 : interval;
       return hap.withValue(() => hap.value + semitones);
     }
+    if (typeof hap.value === 'object')
+      return hap.withValue(() => ({ ...hap.value, note: Note.simplify(Note.transpose(hap.value.note, interval)) }));
     // TODO: move simplify to player to preserve enharmonics
     // tone.js doesn't understand multiple sharps flats e.g. F##3 has to be turned into G3
     return hap.withValue(() => Note.simplify(Note.transpose(hap.value, interval)));
@@ -133,6 +135,11 @@ export const scaleTranspose = register('scaleTranspose', function (offset /* : n
     if (!hap.context.scale) {
       throw new Error('can only use scaleTranspose after .scale');
     }
+    if (typeof hap.value === 'object')
+      return hap.withValue(() => ({
+        ...hap.value,
+        note: scaleOffset(hap.context.scale, Number(offset), hap.value.note),
+      }));
     if (typeof hap.value !== 'string') {
       throw new Error('can only use scaleTranspose with notes');
     }


### PR DESCRIPTION
Now transpose() and scaleTranspose() can be called without disrupting the hap value object contents, it detects the object type and alters the note property only.

Now this function can be safely used in place of add()/sub(), in cases when control properties are already set inside the hap and we don't want to get altered by add().

Use case:
```
n("0 1 2").pan(0.0).gain(0.5).scale("c:major").transpose(12)
```



