### PR TITLE
add debounce to logger

### DIFF
--- a/packages/core/logger.mjs
+++ b/packages/core/logger.mjs
@@ -1,6 +1,16 @@
 export const logKey = 'strudel.log';
 
+let debounce = 1000,
+  lastMessage,
+  lastTime;
+
 export function logger(message, type, data = {}) {
+  let t = performance.now();
+  if (lastMessage === message && t - lastTime < debounce) {
+    return;
+  }
+  lastMessage = message;
+  lastTime = t;
   console.log(`%c${message}`, 'background-color: black;color:white;border-radius:15px');
   if (typeof document !== 'undefined' && typeof CustomEvent !== 'undefined') {
     document.dispatchEvent(


### PR DESCRIPTION
when a runtime error occurs, the console is spammed with logs at 20Hz (query time). this can sometimes even block the ui. to avoid that, I've added a throttling / debounce to the logger, where the same message can only be repeated once per second.