### PR TITLE
Added ability to mute a synth/sound after it was triggered

### DIFF
--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -518,6 +518,7 @@ export const superdough = async (value, deadline, hapDuration) => {
   // toDisconnect = all the node that should be disconnected in onended callback
   // this is crucial for performance
   toDisconnect = chain.concat([delaySend, reverbSend, analyserSend]);
+  return { mute: (dt) => post.gain.linearRampToValueAtTime(0, ac.currentTime + dt) };
 };
 
 export const superdoughTrigger = (t, hap, ct, cps) => superdough(hap, t - ct, hap.duration / cps, cps);


### PR DESCRIPTION
I would like to introduce an ability to control synth or sample after it was triggered. For now I just need the ability to mute, but I am open to implementing control over other aspects of sound too.

Here is an example of what I'm using this for:

```
await WebMidi.enable()
const myInput = WebMidi.inputs[0];
const noteControls = Array.from(Array(128)).map(x => null)
myInput.removeListener('noteon');
myInput.removeListener('noteoff');
myInput.addListener('noteon', e => {
  const [n, vel] = e.dataBytes;
  superdough({ note: n, s: 'piano', postgain: vel / 127 }, 0.05, 10).then(function (x) {
    noteControls[n] = x;
  });
});
myInput.addListener('noteoff', e => {
  const [note] = e.dataBytes;
  const { mute } = noteControls[note]
  mute(0.1);
  noteControls[note] = null
})

sound("metal casio casio casio")
```