### PR TITLE
Little fix for control.mjs + Proposed modification to scale()

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -15,7 +15,7 @@ export function createParam(names) {
     let bag;
     // check if we have an object with an unnamed control (.value)
     if (typeof xs === 'object' && xs.value !== undefined) {
-      bag = { ...xs}; // grab props that are already there
+      bag = { ...xs }; // grab props that are already there
       xs = xs.value; // grab the unnamed control for this one
       delete bag.value;
     }

--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -15,7 +15,7 @@ export function createParam(names) {
     let bag;
     // check if we have an object with an unnamed control (.value)
     if (typeof xs === 'object' && xs.value !== undefined) {
-      bag = xs; // grab props that are already there
+      bag = { ...xs}; // grab props that are already there
       xs = xs.value; // grab the unnamed control for this one
       delete bag.value;
     }
@@ -28,7 +28,8 @@ export function createParam(names) {
       });
       return result;
     } else if (bag) {
-      return { ...bag, [name]: xs };
+      bag[name] = xs;
+      return bag;
     } else {
       return { [name]: xs };
     }

--- a/packages/tonal/tonal.mjs
+++ b/packages/tonal/tonal.mjs
@@ -180,11 +180,14 @@ export const scale = register('scale', function (scale, pat) {
         const isObject = typeof value === 'object';
         let step = isObject ? value.n : value;
         if (isObject) {
+          value = { ...value };
           delete value.n; // remove n so it won't cause trouble
         }
         if (isNote(step)) {
-          // legacy..
-          return pure(step);
+          if (isObject) {
+            value.note = step;
+            return pure(value);
+          } else return pure(step); // legacy
         }
         const asNumber = Number(step);
         if (isNaN(asNumber)) {
@@ -198,12 +201,14 @@ export const scale = register('scale', function (scale, pat) {
           } else {
             note = scaleStep(asNumber, scale);
           }
-          value = pure(isObject ? { ...value, note } : note);
+          if (isObject) {
+            value.note = note;
+            return pure(value);
+          } else return pure(note); // legacy
         } catch (err) {
           logger(`[tonal] ${err.message}`, 'error');
-          value = silence;
+          return silence;
         }
-        return value;
       })
       .outerJoin()
       // legacy:

--- a/packages/tonal/tonal.mjs
+++ b/packages/tonal/tonal.mjs
@@ -178,13 +178,15 @@ export const scale = register('scale', function (scale, pat) {
     pat
       .fmap((value) => {
         const isObject = typeof value === 'object';
-        let step = isObject ? value.n : value;
+        const undefinedN = value.n === undefined;
+        let step = isObject ? (undefinedN ? value.value : value.n) : value;
         if (isObject) {
           value = { ...value };
           delete value.n; // remove n so it won't cause trouble
         }
-        if (isNote(step)) {
+        if (isNote(step) && undefinedN) {
           if (isObject) {
+            if (value.value !== undefined) value.value = step; // transforms the original value
             value.note = step;
             return pure(value);
           } else return pure(step); // legacy
@@ -202,6 +204,7 @@ export const scale = register('scale', function (scale, pat) {
             note = scaleStep(asNumber, scale);
           }
           if (isObject) {
+            if (value.value !== undefined && undefinedN) value.value = note; // transforms the original value
             value.note = note;
             return pure(value);
           } else return pure(note); // legacy


### PR DESCRIPTION
EDIT for clarity:
This patch addresses two separate instances:
- A little bug fix in controls.mjs 
- A proposed change to scale() to make these two lines equivalent in behaviour:
```
"0 c#".scale("c:major").note()...[chain of control functions]   // legacy version
"0 c#"...[chain of control functions]...scale("c:major")  // proposed version
```
The proposed change allows to things:
- being able to express a mixed pattern of number and notes, like the legacy version
- being able to put the scale() function at the very end of a structured stack() of instruments, all 'tuned' on the same scale, avoiding the repetition of the call for every pattern line in the stack.
