### PR TITLE
fix: share now shares what's visible instead of active

### DIFF
--- a/website/src/repl/Repl.jsx
+++ b/website/src/repl/Repl.jsx
@@ -210,7 +210,7 @@ export function Repl({ embedded = false }) {
     editorRef.current.repl.evaluate(code);
   };
 
-  const handleShare = async () => shareCode(activeCode);
+  const handleShare = async () => shareCode(replState.code);
   const context = {
     embedded,
     started,


### PR DESCRIPTION
when pressing share before pressing play for the first time, the initial "// LOADING" string would be shared.
The fix now just shares the code that is in the editor instead of using the activated code