### PR TITLE
rename trig -> reset, trigzero -> restart

### DIFF
--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -262,7 +262,7 @@ export class Pattern {
   }
 
   // Flatterns patterns of patterns, by retriggering/resetting inner patterns at onsets of outer pattern haps
-  trigJoin(cycleZero = false) {
+  resetJoin(restart = false) {
     const pat_of_pats = this;
     return new Pattern((state) => {
       return (
@@ -273,9 +273,9 @@ export class Pattern {
           .map((outer_hap) => {
             return (
               outer_hap.value
-                // trig = align the inner pattern cycle start to outer pattern haps
-                // Trigzero = align the inner pattern cycle zero to outer pattern haps
-                .late(cycleZero ? outer_hap.whole.begin : outer_hap.whole.begin.cyclePos())
+                // reset = align the inner pattern cycle start to outer pattern haps
+                // restart = align the inner pattern cycle zero to outer pattern haps
+                .late(restart ? outer_hap.whole.begin : outer_hap.whole.begin.cyclePos())
                 .query(state)
                 .map((inner_hap) =>
                   new Hap(
@@ -294,8 +294,8 @@ export class Pattern {
     });
   }
 
-  trigzeroJoin() {
-    return this.trigJoin(true);
+  restartJoin() {
+    return this.resetJoin(true);
   }
 
   // Like the other joins above, joins a pattern of patterns of values, into a flatter
@@ -708,13 +708,13 @@ export class Pattern {
     const otherPat = reify(other);
     return otherPat.fmap((a) => thisPat.fmap((b) => func(b)(a))).squeezeJoin();
   }
-  _opTrig(other, func) {
+  _opReset(other, func) {
     const otherPat = reify(other);
-    return otherPat.fmap((b) => this.fmap((a) => func(a)(b))).trigJoin();
+    return otherPat.fmap((b) => this.fmap((a) => func(a)(b))).resetJoin();
   }
-  _opTrigzero(other, func) {
+  _opRestart(other, func) {
     const otherPat = reify(other);
-    return otherPat.fmap((b) => this.fmap((a) => func(a)(b))).trigzeroJoin();
+    return otherPat.fmap((b) => this.fmap((a) => func(a)(b))).restartJoin();
   }
 
   //////////////////////////////////////////////////////////////////////
@@ -1024,7 +1024,7 @@ function _composeOp(a, b, func) {
     func: [(a, b) => b(a)],
   };
 
-  const hows = ['In', 'Out', 'Mix', 'Squeeze', 'SqueezeOut', 'Trig', 'Trigzero'];
+  const hows = ['In', 'Out', 'Mix', 'Squeeze', 'SqueezeOut', 'Reset', 'Restart'];
 
   // generate methods to do what and how
   for (const [what, [op, preprocess]] of Object.entries(composers)) {
@@ -1113,10 +1113,10 @@ function _composeOp(a, b, func) {
    * s("[<bd lt> sd]*2, hh*8").reset("<x@3 x(5,8)>")
    */
   Pattern.prototype.reset = function (...args) {
-    return this.keepif.trig(...args);
+    return this.keepif.reset(...args);
   };
   Pattern.prototype.resetAll = function (...args) {
-    return this.keep.trig(...args);
+    return this.keep.reset(...args);
   };
   /**
    * Restarts the pattern for each onset of the restart pattern.
@@ -1126,10 +1126,10 @@ function _composeOp(a, b, func) {
    * s("[<bd lt> sd]*2, hh*8").restart("<x@3 x(5,8)>")
    */
   Pattern.prototype.restart = function (...args) {
-    return this.keepif.trigzero(...args);
+    return this.keepif.restart(...args);
   };
   Pattern.prototype.restartAll = function (...args) {
-    return this.keep.trigzero(...args);
+    return this.keep.restart(...args);
   };
 })();
 

--- a/packages/core/signal.mjs
+++ b/packages/core/signal.mjs
@@ -269,7 +269,7 @@ export const pickmodOut = register('pickmodOut', function (lookup, pat) {
  * @returns {Pattern}
  */
 export const pickRestart = register('pickRestart', function (lookup, pat) {
-  return _pick(lookup, pat, false).trigzeroJoin();
+  return _pick(lookup, pat, false).restartJoin();
 });
 
 /** * The same as `pickRestart`, but if you pick a number greater than the size of the list,
@@ -279,7 +279,7 @@ export const pickRestart = register('pickRestart', function (lookup, pat) {
  * @returns {Pattern}
  */
 export const pickmodRestart = register('pickmodRestart', function (lookup, pat) {
-  return _pick(lookup, pat, true).trigzeroJoin();
+  return _pick(lookup, pat, true).restartJoin();
 });
 
 /** * Similar to `pick`, but the choosen pattern is reset when its index is triggered.
@@ -288,7 +288,7 @@ export const pickmodRestart = register('pickmodRestart', function (lookup, pat) 
  * @returns {Pattern}
  */
 export const pickReset = register('pickReset', function (lookup, pat) {
-  return _pick(lookup, pat, false).trigJoin();
+  return _pick(lookup, pat, false).resetJoin();
 });
 
 /** * The same as `pickReset`, but if you pick a number greater than the size of the list,
@@ -298,7 +298,7 @@ export const pickReset = register('pickReset', function (lookup, pat) {
  * @returns {Pattern}
  */
 export const pickmodReset = register('pickmodReset', function (lookup, pat) {
-  return _pick(lookup, pat, true).trigJoin();
+  return _pick(lookup, pat, true).resetJoin();
 });
 
 /**

--- a/packages/core/test/pattern.test.mjs
+++ b/packages/core/test/pattern.test.mjs
@@ -181,18 +181,18 @@ describe('Pattern', () => {
         new Hap(ts(1 / 2, 2 / 3), ts(1 / 2, 2 / 3), 7),
       ]);
     });
-    it('can Trig() structure', () => {
+    it('can Reset() structure', () => {
       sameFirst(
         slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10)
-          .add.trig(20, 30)
+          .add.reset(20, 30)
           .early(2),
         sequence(26, 27, 36, 37),
       );
     });
-    it('can Trigzero() structure', () => {
+    it('can Restart() structure', () => {
       sameFirst(
         slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10)
-          .add.trigzero(20, 30)
+          .add.restart(20, 30)
           .early(2),
         sequence(21, 22, 31, 32),
       );
@@ -233,18 +233,18 @@ describe('Pattern', () => {
         new Hap(ts(1 / 2, 2 / 3), ts(1 / 2, 2 / 3), 2),
       ]);
     });
-    it('can Trig() structure', () => {
+    it('can Reset() structure', () => {
       sameFirst(
         slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10)
-          .keep.trig(20, 30)
+          .keep.reset(20, 30)
           .early(2),
         sequence(6, 7, 6, 7),
       );
     });
-    it('can Trigzero() structure', () => {
+    it('can Restart() structure', () => {
       sameFirst(
         slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10)
-          .keep.trigzero(20, 30)
+          .keep.restart(20, 30)
           .early(2),
         sequence(1, 2, 1, 2),
       );
@@ -279,18 +279,18 @@ describe('Pattern', () => {
         new Hap(ts(1 / 2, 2 / 3), ts(1 / 2, 2 / 3), 2),
       ]);
     });
-    it('can Trig() structure', () => {
+    it('can Reset() structure', () => {
       sameFirst(
         slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10)
-          .keepif.trig(false, true)
+          .keepif.reset(false, true)
           .early(2),
         sequence(silence, silence, 6, 7),
       );
     });
-    it('can Trigzero() structure', () => {
+    it('can Restart() structure', () => {
       sameFirst(
         slowcat(sequence(1, 2, 3, 4), 5, sequence(6, 7, 8, 9), 10)
-          .keepif.trigzero(false, true)
+          .keepif.restart(false, true)
           .early(2),
         sequence(silence, silence, 1, 2),
       );

--- a/website/src/pages/technical-manual/alignment.mdx
+++ b/website/src/pages/technical-manual/alignment.mdx
@@ -41,8 +41,8 @@ This makes way for other ways to align the pattern, and several are already defi
 - `mix` - structures from both patterns are combined, so that the new events are not fragments but are created at intersections of events from both sides.
 - `squeeze` - cycles from the pattern on the right are squeezed into events on the left. So that e.g. `"0 1 2".add.squeeze("10 20")` is equivalent to `"[10 20] [11 21] [12 22]"`.
 - `squeezeout` - as with `squeeze`, but cycles from the left are squeezed into events on the right. So, `"0 1 2".add.squeezeout("10 20")` is equivalent to `[10 11 12] [20 21 22]`.
-- `trig` is similar to `squeezeout` in that cycles from the right are aligned with events on the left. However those cycles are not 'squeezed', rather they are truncated to fit the event. So `"0 1 2 3 4 5 6 7".add.trig("10 [20 30]")` would be equivalent to `10 11 12 13 20 21 30 31`. In effect, events on the right 'trigger' cycles on the left.
-- `trigzero` is similar to `trig`, but the pattern is 'triggered' from its very first cycle, rather than from the current cycle. `trig` and `trigzero` therefore only give different results where the leftmost pattern differs from one cycle to the next.
+- `reset` is similar to `squeezeout` in that cycles from the right are aligned with events on the left. However those cycles are not 'squeezed', rather they are truncated to fit the event. So `"0 1 2 3 4 5 6 7".add.trig("10 [20 30]")` would be equivalent to `10 11 12 13 20 21 30 31`. In effect, events on the right 'trigger' cycles on the left.
+- `restart` is similar to `reset`, but the pattern is 'restarted' from its very first cycle, rather than from the current cycle. `reset` and `restart` therefore only give different results where the leftmost pattern differs from one cycle to the next.
 
 We will save going deeper into the background, design and practicalities of these alignment functions for future publications. However in the next section, we take them as a case study for looking at the different design affordances offered by Haskell to Tidal, and JavaScript to Strudel.
 

--- a/website/src/pages/technical-manual/internals.mdx
+++ b/website/src/pages/technical-manual/internals.mdx
@@ -60,13 +60,13 @@ These functions are more low level, probably not needed by the live coder.
 
 <JsDoc client:idle name="Pattern#innerJoin" h={0} />
 
-## trigJoin
+## resetJoin
 
-<JsDoc client:idle name="Pattern#trigJoin" h={0} />
+<JsDoc client:idle name="Pattern#resetJoin" h={0} />
 
-## trigzeroJoin
+## restartJoin
 
-<JsDoc client:idle name="Pattern#trigzeroJoin" h={0} />
+<JsDoc client:idle name="Pattern#restartJoin" h={0} />
 
 ## squeezeJoin
 


### PR DESCRIPTION
renames trig to reset and trigzero to restart in all places

this is a breaking change that should affect very little patterns, as the alignment feature is not very used often. to update your pattern, replace:

```js
x.add.trig(...)
// with
x.add.reset(...)
// or
x.add.trigzero(...)
// with
x.add.restart(...)
```

partly adresses https://github.com/tidalcycles/strudel/issues/970