### PR TITLE
add setting for sync flag

### DIFF
--- a/website/src/repl/Repl.jsx
+++ b/website/src/repl/Repl.jsx
@@ -61,12 +61,12 @@ async function getModule(name) {
 
 export function Repl({ embedded = false }) {
   const isEmbedded = embedded || isIframe;
-  const { panelPosition, isZen } = useSettings();
+  const { panelPosition, isZen, isSyncEnabled } = useSettings();
   const init = useCallback(() => {
     const drawTime = [-2, 2];
     const drawContext = getDrawContext();
     const editor = new StrudelMirror({
-      sync: false,
+      sync: isSyncEnabled,
       defaultOutput: webaudioOutput,
       getTime: () => getAudioContext().currentTime,
       setInterval,

--- a/website/src/repl/panel/SettingsTab.jsx
+++ b/website/src/repl/panel/SettingsTab.jsx
@@ -88,6 +88,7 @@ export function SettingsTab({ started }) {
     isAutoCompletionEnabled,
     isTooltipEnabled,
     isFlashEnabled,
+    isSyncEnabled,
     isLineWrappingEnabled,
     fontSize,
     fontFamily,
@@ -181,6 +182,16 @@ export function SettingsTab({ started }) {
           label="Enable flashing on evaluation"
           onChange={(cbEvent) => settingsMap.setKey('isFlashEnabled', cbEvent.target.checked)}
           value={isFlashEnabled}
+        />
+        <Checkbox
+          label="Sync across Browser Tabs / Windows"
+          onChange={(cbEvent) => {
+            if (confirm('Changing this setting requires the window to reload itself. OK?')) {
+              settingsMap.setKey('isSyncEnabled', cbEvent.target.checked);
+              window.location.reload();
+            }
+          }}
+          value={isSyncEnabled}
         />
       </FormItem>
       <FormItem label="Zen Mode">Try clicking the logo in the top left!</FormItem>

--- a/website/src/settings.mjs
+++ b/website/src/settings.mjs
@@ -13,7 +13,7 @@ export const defaultSettings = {
   isAutoCompletionEnabled: false,
   isTooltipEnabled: false,
   isFlashEnabled: true,
-  isSyncEnabled: true,
+  isSyncEnabled: false,
   isLineWrappingEnabled: false,
   isPatternHighlightingEnabled: true,
   theme: 'strudelTheme',

--- a/website/src/settings.mjs
+++ b/website/src/settings.mjs
@@ -13,6 +13,7 @@ export const defaultSettings = {
   isAutoCompletionEnabled: false,
   isTooltipEnabled: false,
   isFlashEnabled: true,
+  isSyncEnabled: true,
   isLineWrappingEnabled: false,
   isPatternHighlightingEnabled: true,
   theme: 'strudelTheme',
@@ -29,6 +30,8 @@ export const defaultSettings = {
 
 export const settingsMap = persistentMap('strudel-settings', defaultSettings);
 
+const parseBoolean = (booleanlike) => ([true, 'true'].includes(booleanlike) ? true : false);
+
 export function useSettings() {
   const state = useStore(settingsMap);
 
@@ -40,15 +43,16 @@ export function useSettings() {
   });
   return {
     ...state,
-    isZen: [true, 'true'].includes(state.isZen) ? true : false,
-    isBracketMatchingEnabled: [true, 'true'].includes(state.isBracketMatchingEnabled) ? true : false,
-    isLineNumbersDisplayed: [true, 'true'].includes(state.isLineNumbersDisplayed) ? true : false,
-    isActiveLineHighlighted: [true, 'true'].includes(state.isActiveLineHighlighted) ? true : false,
-    isAutoCompletionEnabled: [true, 'true'].includes(state.isAutoCompletionEnabled) ? true : false,
-    isPatternHighlightingEnabled: [true, 'true'].includes(state.isPatternHighlightingEnabled) ? true : false,
-    isTooltipEnabled: [true, 'true'].includes(state.isTooltipEnabled) ? true : false,
-    isLineWrappingEnabled: [true, 'true'].includes(state.isLineWrappingEnabled) ? true : false,
-    isFlashEnabled: [true, 'true'].includes(state.isFlashEnabled) ? true : false,
+    isZen: parseBoolean(state.isZen),
+    isBracketMatchingEnabled: parseBoolean(state.isBracketMatchingEnabled),
+    isLineNumbersDisplayed: parseBoolean(state.isLineNumbersDisplayed),
+    isActiveLineHighlighted: parseBoolean(state.isActiveLineHighlighted),
+    isAutoCompletionEnabled: parseBoolean(state.isAutoCompletionEnabled),
+    isPatternHighlightingEnabled: parseBoolean(state.isPatternHighlightingEnabled),
+    isTooltipEnabled: parseBoolean(state.isTooltipEnabled),
+    isLineWrappingEnabled: parseBoolean(state.isLineWrappingEnabled),
+    isFlashEnabled: parseBoolean(state.isFlashEnabled),
+    isSyncEnabled: parseBoolean(state.isSyncEnabled),
     fontSize: Number(state.fontSize),
     panelPosition: state.activeFooter !== '' ? state.panelPosition : 'bottom', // <-- keep this 'bottom' where it is!
     userPatterns: userPatterns,


### PR DESCRIPTION
adds "Sync across Browser Tabs / Windows" checkbox to toggle the sync feature.

Not sure what the best default setting would be, but I'd lean towards not syncing by default (at least for now), because there is still this bug ( https://github.com/tidalcycles/strudel/issues/1017 ) + the not synced logic seems to have fewer glitches which might be an indicator for better performance.
I am planning to do more testing on lower end devices to find out if it makes a difference.
Most people are probably not aware that the sync even works, so it would need to be mentioned somewhere in the docs, where the setting can be mentioned too. edit: it's disabled by default for now