### PR TITLE
remove dangerous arithmetic feature

### DIFF
--- a/packages/core/test/value.test.mjs
+++ b/packages/core/test/value.test.mjs
@@ -22,8 +22,4 @@ describe('Value', () => {
     expect(valued(mul).ap(3).ap(3).value).toEqual(9);
     expect(valued(3).mul(3).value).toEqual(9);
   });
-  it('union bare numbers for numeral props', () => {
-    expect(n(3).cutoff(500).add(10).firstCycleValues).toEqual([{ n: 13, cutoff: 510 }]);
-    expect(n(3).cutoff(500).mul(2).firstCycleValues).toEqual([{ n: 6, cutoff: 1000 }]);
-  });
 });

--- a/packages/core/value.mjs
+++ b/packages/core/value.mjs
@@ -5,14 +5,13 @@ This program is free software: you can redistribute it and/or modify it under th
 */
 
 import { curry } from './util.mjs';
+import { logger } from './logger.mjs';
 
 export function unionWithObj(a, b, func) {
-  if (typeof b?.value === 'number') {
-    // https://github.com/tidalcycles/strudel/issues/262
-    const numKeys = Object.keys(a).filter((k) => typeof a[k] === 'number');
-    const numerals = Object.fromEntries(numKeys.map((k) => [k, b.value]));
-    b = Object.assign(b, numerals);
-    delete b.value;
+  if (b?.value !== undefined && Object.keys(b).length === 1) {
+    // https://github.com/tidalcycles/strudel/issues/1026
+    logger(`[warn]: dangerous arithmetic`);
+    return a;
   }
   const common = Object.keys(a).filter((k) => Object.keys(b).includes(k));
   return Object.assign({}, a, b, Object.fromEntries(common.map((k) => [k, func(a[k], b[k])])));

--- a/packages/core/value.mjs
+++ b/packages/core/value.mjs
@@ -10,7 +10,7 @@ import { logger } from './logger.mjs';
 export function unionWithObj(a, b, func) {
   if (b?.value !== undefined && Object.keys(b).length === 1) {
     // https://github.com/tidalcycles/strudel/issues/1026
-    logger(`[warn]: dangerous arithmetic`);
+    logger(`[warn]: Can't do arithmetic on control pattern.`);
     return a;
   }
   const common = Object.keys(a).filter((k) => Object.keys(b).includes(k));

--- a/website/src/repl/tunes.mjs
+++ b/website/src/repl/tunes.mjs
@@ -361,8 +361,8 @@ export const echoPiano = `// "Echo piano"
 // @by Felix Roos
 
 n("<0 2 [4 6](3,4,2) 3*2>").color('salmon')
-.off(1/4, x=>x.add(2).color('green'))
-.off(1/2, x=>x.add(6).color('steelblue'))
+.off(1/4, x=>x.add(n(2)).color('green'))
+.off(1/2, x=>x.add(n(6)).color('steelblue'))
 .scale('D minor')
 .echo(4, 1/8, .5)
 .clip(.5)


### PR DESCRIPTION
fixes https://github.com/tidalcycles/strudel/issues/1026

currently just logs `[warn]: dangerous arithmetic` when something like `n(1).add(1)` is attempted.
Or maybe remove the log?