### PR TITLE
fix cyclist fizzling out

### DIFF
--- a/packages/core/cyclist.mjs
+++ b/packages/core/cyclist.mjs
@@ -37,11 +37,16 @@ export class Cyclist {
           this.lastBegin = begin;
           const end = this.num_cycles_at_cps_change + num_cycles_since_cps_change;
           this.lastEnd = end;
+          this.lastTick = phase;
+
+          if (phase < t) {
+            // avoid querying haps that are in the past anyway
+            console.log(`skip query: too late`);
+            return;
+          }
 
           // query the pattern for events
           const haps = this.pattern.queryArc(begin, end, { _cps: this.cps });
-
-          this.lastTick = phase;
 
           haps.forEach((hap) => {
             if (hap.hasOnset()) {

--- a/packages/core/zyklus.mjs
+++ b/packages/core/zyklus.mjs
@@ -26,8 +26,7 @@ function createClock(
     // callback as long as we're inside the lookahead
     while (phase < lookahead) {
       phase = round ? Math.round(phase * precision) / precision : phase;
-      phase >= t && callback(phase, duration, tick, t);
-      phase < t && console.log('TOO LATE', phase); // what if latency is added from outside?
+      callback(phase, duration, tick, t); // callback has to skip / handle phase < t!
       phase += duration; // increment phase by duration
       tick++;
     }

--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -273,6 +273,12 @@ export const superdough = async (value, t, hapDuration) => {
   value.duration = hapDuration;
   // calculate absolute time
   t = typeof t === 'string' && t.startsWith('=') ? Number(t.slice(1)) : ac.currentTime + t;
+  if (t < ac.currentTime) {
+    console.log(
+      `[superdough]: cannot schedule sounds in the past (target: ${t.toFixed(2)}, now: ${ac.currentTime.toFixed(2)})`,
+    );
+    return;
+  }
   // destructure
   let {
     s = 'triangle',

--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -274,7 +274,7 @@ export const superdough = async (value, t, hapDuration) => {
   // calculate absolute time
   t = typeof t === 'string' && t.startsWith('=') ? Number(t.slice(1)) : ac.currentTime + t;
   if (t < ac.currentTime) {
-    console.log(
+    console.warn(
       `[superdough]: cannot schedule sounds in the past (target: ${t.toFixed(2)}, now: ${ac.currentTime.toFixed(2)})`,
     );
     return;


### PR DESCRIPTION
fixes a regression introduced in https://github.com/tidalcycles/strudel/pull/1004

a blocking of the main thread might have caused the cyclist to not recover from a desync...

1. zyklus did skip callbacks that are in the past (infamous TOO LATE messages). For testing, blocking zyklus can easily be achieved by opening an alert (or through heavy mean thread load). in the real world, this can also happen due to heavy momentary load (major gc)
2. when the zyklus callback is not invoked, the cyclist does not tick, so num_ticks_since_cps_change is not incremented, which means it slides into the past.

the fix was to always invoke the callback from zyklus and let cyclist skip queries that are in the past. 
Now the cyclist should be able to recover from any main thread blocking, because cyclist will just fire all missed callbacks until we're in the present again, keeping the cyclist state in sync with reality
