### PR TITLE
fix: do not reset cc input values on each eval

### DIFF
--- a/packages/midi/midi.mjs
+++ b/packages/midi/midi.mjs
@@ -177,7 +177,7 @@ export async function midin(input) {
   }
   const initial = await enableWebMidi(); // only returns on first init
   const device = getDevice(input, WebMidi.inputs);
-  if (initial || WebMidi.enabled) {
+  if (initial) {
     const otherInputs = WebMidi.inputs.filter((o) => o.name !== device.name);
     logger(
       `Midi enabled! Using "${device.name}". ${


### PR DESCRIPTION
fix regression introduced in https://github.com/tidalcycles/strudel/pull/936

when using midin, the input state was reset on each evaluation..