### PR TITLE
anonymous patterns + muting

### DIFF
--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -54,10 +54,12 @@ export function repl({
   const scheduler =
     sync && typeof SharedWorker != 'undefined' ? new NeoCyclist(schedulerOptions) : new Cyclist(schedulerOptions);
   let pPatterns = {};
+  let anonymousIndex = 0;
   let allTransform;
 
   const hush = function () {
     pPatterns = {};
+    anonymousIndex = 0;
     allTransform = undefined;
     return silence;
   };
@@ -82,6 +84,15 @@ export function repl({
   // set pattern methods that use this repl via closure
   const injectPatternMethods = () => {
     Pattern.prototype.p = function (id) {
+      if (id.startsWith('_') || id.endsWith('_')) {
+        // allows muting a pattern x with x_ or _x
+        return silence;
+      }
+      if (id === '$') {
+        // allows adding anonymous patterns with $:
+        id = `$${anonymousIndex}`;
+        anonymousIndex++;
+      }
       pPatterns[id] = this;
       return this;
     };


### PR DESCRIPTION
1. adds the ability to create an anonymous patterns with a `$:` label

```js
$: s("bd")
$: s("hh*4")
```

this is handy because you won't have to name your patterns. I found myself just keyboard mashing random characters in a live situation because i just needed a unique name quickly.

2. adds the ability to mute a labeled pattern by adding a _ before or after:

```js
p1_: s("bd")
$_: s("hh*4")
```

I've started out with just a prefix, but I've noticed that the click area of the first column in each line is half as big as the click aread of the other columns. Maybe just a suffix is enough..

credits to @geikha for the idea