### PR TITLE
clarify `off` in pattern-effects.mdx

### DIFF
--- a/website/src/pages/de/workshop/pattern-effects.mdx
+++ b/website/src/pages/de/workshop/pattern-effects.mdx
@@ -147,7 +147,7 @@ Probier `ply` mit einem pattern zu automatisieren, z.b. `"<1 2 1 3>"`
   .off(1/8, x=>x.add(4))
   //.off(1/4, x=>x.add(7))
 ).scale("<C5:minor Db5:mixolydian>/4")
-.s("triangle").room(.5).ds(".1:0").delay(.5)`}
+.s("triangle").room(.5).dec(.1).delay(.5)`}
   punchcard
 />
 

--- a/website/src/pages/workshop/pattern-effects.mdx
+++ b/website/src/pages/workshop/pattern-effects.mdx
@@ -145,13 +145,16 @@ Try patterning the `ply` function, for example using `"<1 2 1 3>"`
   .off(1/16, x=>x.add(4))
   //.off(1/8, x=>x.add(7))
 ).scale("<C5:minor Db5:mixolydian>/2")
-.s("triangle").room(.5).ds(".1:0").delay(.5)`}
+.s("triangle").room(.5).ds("0.1:0")`}
   punchcard
 />
 
 <Box>
 
-In the notation `x=>x.`, the `x` is the shifted pattern, which where modifying.
+In the notation `.off(1/16, x=>x.add(4))`, says:
+ - take the original pattern named as `x`
+ - modify `x` with `.add(4)`, and 
+ - play it offset to the original pattern by `1/16` of a cycle.
 
 </Box>
 

--- a/website/src/pages/workshop/pattern-effects.mdx
+++ b/website/src/pages/workshop/pattern-effects.mdx
@@ -152,9 +152,10 @@ Try patterning the `ply` function, for example using `"<1 2 1 3>"`
 <Box>
 
 In the notation `.off(1/16, x=>x.add(4))`, says:
- - take the original pattern named as `x`
- - modify `x` with `.add(4)`, and 
- - play it offset to the original pattern by `1/16` of a cycle.
+
+- take the original pattern named as `x`
+- modify `x` with `.add(4)`, and
+- play it offset to the original pattern by `1/16` of a cycle.
 
 </Box>
 

--- a/website/src/pages/workshop/pattern-effects.mdx
+++ b/website/src/pages/workshop/pattern-effects.mdx
@@ -145,7 +145,7 @@ Try patterning the `ply` function, for example using `"<1 2 1 3>"`
   .off(1/16, x=>x.add(4))
   //.off(1/8, x=>x.add(7))
 ).scale("<C5:minor Db5:mixolydian>/2")
-.s("triangle").room(.5).ds("0.1:0")`}
+.s("triangle").room(.5).dec(.1)`}
   punchcard
 />
 


### PR DESCRIPTION
I had a bit of difficulty understanding `off` as it was presented, so I've attempted to simplify it:
1. take out the `delay` effect which is obscuring things (since we're using a delayed `off` pattern)
2. add a more complete explanation of the syntax