### PR TITLE
fix: url parsing with extra params

### DIFF
--- a/website/src/repl/util.mjs
+++ b/website/src/repl/util.mjs
@@ -26,13 +26,13 @@ export async function initCode() {
   // load code from url hash (either short hash from database or decode long hash)
   try {
     const initialUrl = window.location.href;
-    const hash = initialUrl.split('?')[1]?.split('#')?.[0];
+    const hash = initialUrl.split('?')[1]?.split('#')?.[0]?.split('&')[0];
     const codeParam = window.location.href.split('#')[1] || '';
-    // looking like https://strudel.cc/?J01s5i1J0200 (fixed hash length)
     if (codeParam) {
       // looking like https://strudel.cc/#ImMzIGUzIg%3D%3D (hash length depends on code length)
       return hash2code(codeParam);
     } else if (hash) {
+      // looking like https://strudel.cc/?J01s5i1J0200 (fixed hash length)
       return supabase
         .from('code_v1')
         .select('code')


### PR DESCRIPTION
urls with extra params did not work, like `https://strudel.cc/?pzSi6Np11qdV&authuser=0`