### PR TITLE
Use sessionStorage for viewingPatternData and activePattern

### DIFF
--- a/website/src/user_pattern_utils.mjs
+++ b/website/src/user_pattern_utils.mjs
@@ -21,39 +21,25 @@ export const patternFilterName = {
   user: 'user',
 };
 
-export let sessionAtom = persistentAtom;
+const sessionAtom = (name, initial = undefined) => {
+  const storage = typeof sessionStorage !== 'undefined' ? sessionStorage : {};
+  const store = atom(typeof storage[name] !== 'undefined' ? storage[name] : initial);
+  store.listen((newValue) => {
+    if (typeof newValue === 'undefined') {
+      delete storage[name];
+    } else {
+      storage[name] = newValue;
+    }
+  });
+  return store;
+};
 
-if (typeof sessionStorage !== 'undefined') {
-  const identity = (a) => a;
-  sessionAtom = (name, initial = undefined, opts = {}) => {
-    let encode = opts.encode || identity;
-    let decode = opts.decode || identity;
-    if (opts.listen) console.error('sessionAtom does not support "listen" option');
-
-    let store = atom(typeof sessionStorage[name] !== 'undefined' ? decode(sessionStorage[name]) : initial);
-
-    store.listen((newValue) => {
-      if (typeof newValue === 'undefined') {
-        delete sessionStorage[name];
-      } else {
-        sessionStorage[name] = encode(newValue);
-      }
-    });
-
-    return store;
-  };
-}
-
-export let $viewingPatternData = sessionAtom(
-  'viewingPatternData',
-  {
-    id: '',
-    code: '',
-    collection: collectionName.user,
-    created_at: Date.now(),
-  },
-  { listen: false },
-);
+export let $viewingPatternData = sessionAtom('viewingPatternData', {
+  id: '',
+  code: '',
+  collection: collectionName.user,
+  created_at: Date.now(),
+});
 
 export const getViewingPatternData = () => {
   return parseJSON($viewingPatternData.get());
@@ -91,7 +77,7 @@ export async function loadDBPatterns() {
 }
 
 // reason: https://github.com/tidalcycles/strudel/issues/857
-const $activePattern = sessionAtom('activePattern', '', { listen: false });
+const $activePattern = sessionAtom('activePattern', '');
 
 export function setActivePattern(key) {
   $activePattern.set(key);

--- a/website/src/user_pattern_utils.mjs
+++ b/website/src/user_pattern_utils.mjs
@@ -1,5 +1,5 @@
 import { atom } from 'nanostores';
-import { persistentAtom } from '@nanostores/persistent';
+import { persistentAtom, setPersistentEngine } from '@nanostores/persistent';
 import { useStore } from '@nanostores/react';
 import { logger } from '@strudel/core';
 import { nanoid } from 'nanoid';
@@ -20,6 +20,10 @@ export const patternFilterName = {
   community: 'community',
   user: 'user',
 };
+
+if (typeof sessionStorage !== 'undefined') {
+  setPersistentEngine(sessionStorage);
+}
 
 export let $viewingPatternData = persistentAtom(
   'viewingPatternData',

--- a/website/src/user_pattern_utils.mjs
+++ b/website/src/user_pattern_utils.mjs
@@ -1,5 +1,5 @@
 import { atom } from 'nanostores';
-import { persistentAtom, setPersistentEngine } from '@nanostores/persistent';
+import { persistentAtom, setPersistentEngine, windowPersistentEvents } from '@nanostores/persistent';
 import { useStore } from '@nanostores/react';
 import { logger } from '@strudel/core';
 import { nanoid } from 'nanoid';
@@ -22,7 +22,10 @@ export const patternFilterName = {
 };
 
 if (typeof sessionStorage !== 'undefined') {
-  setPersistentEngine(sessionStorage);
+  // NB: this switches storageEngine of all persistent atoms
+  // ideally we would switch the engine per atom
+  // (like in this abandoned pr: https://github.com/nanostores/persistent/pull/30)
+  setPersistentEngine(sessionStorage, windowPersistentEvents);
 }
 
 export let $viewingPatternData = persistentAtom(

--- a/website/src/user_pattern_utils.mjs
+++ b/website/src/user_pattern_utils.mjs
@@ -1,4 +1,4 @@
-import { atom, onMount } from 'nanostores';
+import { atom } from 'nanostores';
 import { persistentAtom } from '@nanostores/persistent';
 import { useStore } from '@nanostores/react';
 import { logger } from '@strudel/core';

--- a/website/src/user_pattern_utils.mjs
+++ b/website/src/user_pattern_utils.mjs
@@ -30,7 +30,7 @@ if (typeof sessionStorage !== 'undefined') {
     let decode = opts.decode || identity;
     if (opts.listen) console.error('sessionAtom does not support "listen" option');
 
-    let store = atom(sessionStorage[name] ? decode(sessionStorage[name]) : initial);
+    let store = atom(typeof sessionStorage[name] !== 'undefined' ? decode(sessionStorage[name]) : initial);
 
     store.listen((newValue) => {
       if (typeof newValue === 'undefined') {


### PR DESCRIPTION
localStorage, which is shared between tabs, was being used for these, and although it wasn't [live] synchronised between tabs, it would e.g. restore to the last saved data (accross all tabs) upon refresh/reload/new window. 

sessionStorage is separate for each tab, but persists tab data across refreshes.

this should fix #1049 as it's tracking the data about which pattern is active/selected for each tab separately.