### PR TITLE
tonal: 2 small fixes

### DIFF
--- a/packages/tonal/test/tonal.test.mjs
+++ b/packages/tonal/test/tonal.test.mjs
@@ -30,11 +30,26 @@ describe('tonal', () => {
         .firstCycleValues.map((h) => h.note),
     ).toEqual(['C3', 'D3', 'E3']);
   });
+  it('scale with n and note values', () => {
+    expect(
+        n(0, 1, 2)
+            .note(3, 4, 5)
+            .scale('C major')
+            .firstCycleValues.map((h) => h.note),
+    ).toEqual(['F3', 'G3', 'A3']);
+  });
   it('scale with colon', () => {
     expect(
       n(0, 1, 2)
         .scale('C:major')
         .firstCycleValues.map((h) => h.note),
+    ).toEqual(['C3', 'D3', 'E3']);
+  });
+  it('scale without tonic', () => {
+    expect(
+        n(0, 1, 2)
+            .scale('major')
+            .firstCycleValues.map((h) => h.note),
     ).toEqual(['C3', 'D3', 'E3']);
   });
   it('scale with mininotation colon', () => {

--- a/packages/tonal/tonal.mjs
+++ b/packages/tonal/tonal.mjs
@@ -14,7 +14,7 @@ function scaleStep(step, scale) {
   scale = scale.replaceAll(':', ' ');
   step = Math.ceil(step);
   let { intervals, tonic, empty } = Scale.get(scale);
-  if ((empty && isNote(scale)) || (!empty && !tonic)) {
+  if ((empty && isNote(scale)) || (empty && !tonic)) {
     throw new Error(`incomplete scale. Make sure to use ":" instead of spaces, example: .scale("C:major")`);
   } else if (empty) {
     throw new Error(`invalid scale "${scale}"`);
@@ -199,10 +199,7 @@ export const scale = register(
       pat
         .fmap((value) => {
           const isObject = typeof value === 'object';
-          let step = isObject ? value.n : value;
-          if (isObject) {
-            delete value.n; // remove n so it won't cause trouble
-          }
+          let step = isObject ? (value.note ?? value.n) : value;
           if (isNote(step)) {
             // legacy..
             return pure(step);


### PR DESCRIPTION
- fix `scale()` to allow both `n()` and `note()` at the same time
- fix `scale()` to allow scale names without tonic and then default it to C