### PR TITLE
osc: couple of fixes

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -47,7 +47,7 @@ export function createParam(names) {
   return func;
 }
 
-function registerControl(names, ...aliases) {
+export function registerControl(names, ...aliases) {
   const name = Array.isArray(names) ? names[0] : names;
   let bag = {};
   bag[name] = createParam(names);

--- a/packages/osc/osc.mjs
+++ b/packages/osc/osc.mjs
@@ -54,6 +54,7 @@ Pattern.prototype.osc = function () {
     controls.n && (controls.n = parseNumeral(controls.n));
     controls.note && (controls.note = parseNumeral(controls.note));
     controls.bank && (controls.s = controls.bank + controls.s);
+    controls.roomsize && (controls.size = parseNumeral(controls.roomsize));
     const keyvals = Object.entries(controls).flat();
     // time should be audio time of onset
     // currentTime should be current time of audio context (slightly before time)

--- a/packages/osc/osc.mjs
+++ b/packages/osc/osc.mjs
@@ -53,6 +53,7 @@ Pattern.prototype.osc = function () {
     // make sure n and note are numbers
     controls.n && (controls.n = parseNumeral(controls.n));
     controls.note && (controls.note = parseNumeral(controls.note));
+    controls.bank && (controls.s = controls.bank + controls.s);
     const keyvals = Object.entries(controls).flat();
     // time should be audio time of onset
     // currentTime should be current time of audio context (slightly before time)

--- a/packages/osc/osc.mjs
+++ b/packages/osc/osc.mjs
@@ -52,7 +52,7 @@ Pattern.prototype.osc = function () {
     const controls = Object.assign({}, { cps, cycle, delta }, hap.value);
     // make sure n and note are numbers
     controls.n && (controls.n = parseNumeral(controls.n));
-    if (controls.note) {
+    if (typeof controls.note !== 'undefined') {
       if (isNote(controls.note)) {
         controls.midinote = noteToMidi(controls.note, controls.octave || 3);
       } else {

--- a/packages/osc/osc.mjs
+++ b/packages/osc/osc.mjs
@@ -6,7 +6,7 @@ This program is free software: you can redistribute it and/or modify it under th
 
 import OSC from 'osc-js';
 
-import { logger, parseNumeral, Pattern, getEventOffsetMs } from '@strudel/core';
+import {logger, parseNumeral, Pattern, getEventOffsetMs, isNote, noteToMidi} from '@strudel/core';
 
 let connection; // Promise<OSC>
 function connect() {
@@ -52,7 +52,14 @@ Pattern.prototype.osc = function () {
     const controls = Object.assign({}, { cps, cycle, delta }, hap.value);
     // make sure n and note are numbers
     controls.n && (controls.n = parseNumeral(controls.n));
-    controls.note && (controls.note = parseNumeral(controls.note));
+    if (controls.note) {
+      if (isNote(controls.note)) {
+        controls.midinote = noteToMidi(controls.note, controls.octave || 3);
+      }
+      else {
+        controls.note = parseNumeral(controls.note);
+      }
+    }
     controls.bank && (controls.s = controls.bank + controls.s);
     controls.roomsize && (controls.size = parseNumeral(controls.roomsize));
     const keyvals = Object.entries(controls).flat();

--- a/packages/osc/osc.mjs
+++ b/packages/osc/osc.mjs
@@ -6,7 +6,7 @@ This program is free software: you can redistribute it and/or modify it under th
 
 import OSC from 'osc-js';
 
-import {logger, parseNumeral, Pattern, getEventOffsetMs, isNote, noteToMidi} from '@strudel/core';
+import { logger, parseNumeral, Pattern, getEventOffsetMs, isNote, noteToMidi } from '@strudel/core';
 
 let connection; // Promise<OSC>
 function connect() {
@@ -55,8 +55,7 @@ Pattern.prototype.osc = function () {
     if (controls.note) {
       if (isNote(controls.note)) {
         controls.midinote = noteToMidi(controls.note, controls.octave || 3);
-      }
-      else {
+      } else {
         controls.note = parseNumeral(controls.note);
       }
     }

--- a/packages/osc/tidal-sniffer.js
+++ b/packages/osc/tidal-sniffer.js
@@ -4,7 +4,7 @@ Copyright (C) 2022 Strudel contributors - see <https://github.com/tidalcycles/st
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-const OSC = require('osc-js');
+import OSC from 'osc-js';
 
 const config = {
   receiver: 'ws', // @param {string} Where messages sent via 'send' method will be delivered to, 'ws' for Websocket clients, 'udp' for udp client


### PR DESCRIPTION
- fix: if `note` is a midi note, and it's sent together with `octave` to SuperDirt, then that will be wrong. instead we should to `midinote` whenever sure that it's a midi note.
- map`bank` to work like tidal's `drumFrom`
- `roomsize` is `size` in SuperDirt
- fix tidal-sniffer
- I exported `registerControl`, although I could have used `registerParam`, which is already exported... what's the recommendation here, should I be using `registerParam`?