### PR TITLE
add Pattern.every to the docs?

### DIFF
--- a/website/src/pages/learn/conditional-modifiers.mdx
+++ b/website/src/pages/learn/conditional-modifiers.mdx
@@ -18,7 +18,7 @@ import { JsDoc } from '../../docs/JsDoc';
 
 ## every
 
-<JsDoc client:idle name="Pattern.every" h={0}  />
+<JsDoc client:idle name="Pattern.every" h={0} />
 
 ## when
 

--- a/website/src/pages/learn/conditional-modifiers.mdx
+++ b/website/src/pages/learn/conditional-modifiers.mdx
@@ -16,6 +16,10 @@ import { JsDoc } from '../../docs/JsDoc';
 
 <JsDoc client:idle name="Pattern.firstOf" h={0} />
 
+## every
+
+<JsDoc client:idle name="Pattern.every" h={0}  />
+
 ## when
 
 <JsDoc client:idle name="Pattern.when" h={0} />


### PR DESCRIPTION
Coming from TidalCycles I had to dig into the code to find that `every` has been renamed to `firstOf`. I think better to have it clear in the docs.

Now I see it appears in the Reference tab, but initially I was search trough the Learn section and not finding.