### PR TITLE
Gain Modulation with calculated modulation per event

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -431,6 +431,17 @@ export const { crush } = registerControl('crush');
 export const { coarse } = registerControl('coarse');
 
 /**
+ * modulate the output gain of a sound with a continuous wave
+ *
+ * @name gainmod
+ * @param {number | Pattern} factor 1 for original 2 for half, 3 for a third and so on.
+ * @example
+ * s("triangle").gainmod("2:1:0")
+ *
+ */
+export const { gainmod } = registerControl('gainmod');
+
+/**
  * Allows you to set the output channels on the interface
  *
  * @name channels

--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -439,7 +439,7 @@ export const { coarse } = registerControl('coarse');
  * s("triangle").am("2").amshape("<tri saw ramp square>").amdepth(.5)
  *
  */
-export const { am } = registerControl(['am', 'amdepth', 'amshape']);
+export const { am } = registerControl(['am', 'amdepth', 'amskew', 'amphase']);
 
 /**
  * depth of amplitude modulation
@@ -451,6 +451,27 @@ export const { am } = registerControl(['am', 'amdepth', 'amshape']);
  *
  */
 export const { amdepth } = registerControl('amdepth');
+/**
+ * alter the shape of the modulation waveform
+ *
+ * @name amskew
+ * @param {number | Pattern} amount between 0 & 1, the shape of the waveform
+ * @example
+ * note("{f a c e}%16").am(4).amskew("<.5 0 1>")
+ *
+ */
+export const { amskew } = registerControl('amskew');
+
+/**
+ * alter the phase of the modulation waveform
+ *
+ * @name amphase
+ * @param {number | Pattern} offset the offset in cycles of the modulation
+ * @example
+ * note("{f a c e}%16").am(4).amphase("<0 .25 .66>")
+ *
+ */
+export const { amphase } = registerControl('amskew');
 
 /**
  * shape of amplitude modulation

--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -431,16 +431,37 @@ export const { crush } = registerControl('crush');
 export const { coarse } = registerControl('coarse');
 
 /**
- * modulate the output gain of a sound with a continuous wave
+ * modulate the amplitude of a sound with a continuous waveform
  *
- * @name gainmod
- * @param {number | Pattern} factor 1 for original 2 for half, 3 for a third and so on.
+ * @name am
+ * @param {number | Pattern} speed modulation speed in cycles
  * @example
- * s("triangle").gainmod("2:1:0")
+ * s("triangle").am("2").amshape("<tri saw ramp square>").amdepth(.5)
  *
  */
-export const { gainmod } = registerControl('gainmod');
+export const { am } = registerControl(['am', 'amdepth', 'amshape']);
 
+/**
+ * depth of amplitude modulation
+ *
+ * @name amdepth
+ * @param {number | Pattern} depth
+ * @example
+ * s("triangle").am(1).amdepth("1")
+ *
+ */
+export const { amdepth } = registerControl('amdepth');
+
+/**
+ * shape of amplitude modulation
+ *
+ * @name amshape
+ * @param {number | Pattern} shape tri | square | sine | saw | ramp
+ * @example
+ * note("{f g c d}%16").am(4).amshape("ramp").s("sawtooth")
+ *
+ */
+export const { amshape } = registerControl('amshape');
 /**
  * Allows you to set the output channels on the interface
  *

--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -471,7 +471,7 @@ export const { amskew } = registerControl('amskew');
  * note("{f a c e}%16").am(4).amphase("<0 .25 .66>")
  *
  */
-export const { amphase } = registerControl('amskew');
+export const { amphase } = registerControl('amphase');
 
 /**
  * shape of amplitude modulation

--- a/packages/core/cyclist.mjs
+++ b/packages/core/cyclist.mjs
@@ -56,7 +56,7 @@ export class Cyclist {
               // the following line is dumb and only here for backwards compatibility
               // see https://github.com/tidalcycles/strudel/pull/1004
               const deadline = targetTime - phase;
-              onTrigger?.(hap, deadline, duration, this.cps, targetTime);
+              onTrigger?.(hap, deadline, duration, this.cps, targetTime, end);
             }
           });
         } catch (e) {

--- a/packages/core/cyclist.mjs
+++ b/packages/core/cyclist.mjs
@@ -34,6 +34,8 @@ export class Cyclist {
 
         try {
           const begin = this.lastEnd;
+          const cycle = this.now();
+
           this.lastBegin = begin;
           const end = this.num_cycles_at_cps_change + num_cycles_since_cps_change;
           this.lastEnd = end;
@@ -56,7 +58,7 @@ export class Cyclist {
               // the following line is dumb and only here for backwards compatibility
               // see https://github.com/tidalcycles/strudel/pull/1004
               const deadline = targetTime - phase;
-              onTrigger?.(hap, deadline, duration, this.cps, targetTime, end);
+              onTrigger?.(hap, deadline, duration, this.cps, targetTime, cycle);
             }
           });
         } catch (e) {

--- a/packages/core/cyclist.mjs
+++ b/packages/core/cyclist.mjs
@@ -34,12 +34,15 @@ export class Cyclist {
 
         try {
           const begin = this.lastEnd;
-          const cycle = this.now();
 
           this.lastBegin = begin;
           const end = this.num_cycles_at_cps_change + num_cycles_since_cps_change;
+
           this.lastEnd = end;
+
           this.lastTick = phase;
+
+          const cycle = this.now();
 
           if (phase < t) {
             // avoid querying haps that are in the past anyway

--- a/packages/core/neocyclist.mjs
+++ b/packages/core/neocyclist.mjs
@@ -4,6 +4,7 @@ Copyright (C) 2022 Strudel contributors - see <https://github.com/tidalcycles/st
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import Fraction from 'fraction.js';
 import { logger } from './logger.mjs';
 
 export class NeoCyclist {
@@ -86,7 +87,15 @@ export class NeoCyclist {
             this.latency +
             this.worker_time_dif;
           const duration = hap.duration / this.cps;
-          onTrigger?.(hap, 0, duration, this.cps, targetTime);
+          onTrigger?.(
+            hap,
+            0,
+            duration,
+            this.cps,
+            targetTime,
+            this.cycle,
+            // + Fraction(this.latency).div(this.cps)
+          );
         }
       });
     };

--- a/packages/core/neocyclist.mjs
+++ b/packages/core/neocyclist.mjs
@@ -4,7 +4,6 @@ Copyright (C) 2022 Strudel contributors - see <https://github.com/tidalcycles/st
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import Fraction from 'fraction.js';
 import { logger } from './logger.mjs';
 
 export class NeoCyclist {
@@ -87,15 +86,7 @@ export class NeoCyclist {
             this.latency +
             this.worker_time_dif;
           const duration = hap.duration / this.cps;
-          onTrigger?.(
-            hap,
-            0,
-            duration,
-            this.cps,
-            targetTime,
-            this.cycle,
-            // + Fraction(this.latency).div(this.cps)
-          );
+          onTrigger?.(hap, 0, duration, this.cps, targetTime, this.cycle);
         }
       });
     };

--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -178,15 +178,15 @@ export function repl({
 
 export const getTrigger =
   ({ getTime, defaultOutput }) =>
-  async (hap, deadline, duration, cps, t) => {
+  async (hap, deadline, duration, cps, t, cycle = 0) => {
     // TODO: get rid of deadline after https://github.com/tidalcycles/strudel/pull/1004
     try {
       if (!hap.context.onTrigger || !hap.context.dominantTrigger) {
-        await defaultOutput(hap, deadline, duration, cps, t);
+        await defaultOutput(hap, deadline, duration, cps, t, cycle);
       }
       if (hap.context.onTrigger) {
         // call signature of output / onTrigger is different...
-        await hap.context.onTrigger(getTime() + deadline, hap, getTime(), cps, t);
+        await hap.context.onTrigger(getTime() + deadline, hap, getTime(), cps, t, cycle);
       }
     } catch (err) {
       logger(`[cyclist] error: ${err.message}`, 'error');

--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -324,7 +324,7 @@ export const superdough = async (value, t, hapDuration, cps, cycle) => {
     phasercenter,
     //
     coarse,
-    gainmod,
+    am,
     crush,
     shape,
 
@@ -474,11 +474,12 @@ export const superdough = async (value, t, hapDuration, cps, cycle) => {
   crush !== undefined && chain.push(getWorklet(ac, 'crush-processor', { crush }));
   shape !== undefined && chain.push(getWorklet(ac, 'shape-processor', { shape, postgain: shapevol }));
   distort !== undefined && chain.push(getWorklet(ac, 'distort-processor', { distort, postgain: distortvol }));
-  gainmod !== undefined &&
+  am !== undefined &&
     chain.push(
-      getWorklet(ac, 'gainmod-processor', {
-        speed: gainmod,
-        // depth: amdepth, shape: amshape,
+      getWorklet(ac, 'am-processor', {
+        speed: am,
+        depth: amdepth,
+        // shape: amshape,
 
         cps,
         cycle,

--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -260,7 +260,8 @@ export function resetGlobalEffects() {
   analysersData = {};
 }
 
-export const superdough = async (value, t, hapDuration) => {
+export const superdough = async (value, t, hapDuration, cps, cycle) => {
+  console.log({ cps, cycle });
   const ac = getAudioContext();
   if (typeof value !== 'object') {
     throw new Error(
@@ -322,6 +323,7 @@ export const superdough = async (value, t, hapDuration) => {
     phasercenter,
     //
     coarse,
+    gainmod,
     crush,
     shape,
     shapevol = 1,
@@ -470,6 +472,7 @@ export const superdough = async (value, t, hapDuration) => {
   crush !== undefined && chain.push(getWorklet(ac, 'crush-processor', { crush }));
   shape !== undefined && chain.push(getWorklet(ac, 'shape-processor', { shape, postgain: shapevol }));
   distort !== undefined && chain.push(getWorklet(ac, 'distort-processor', { distort, postgain: distortvol }));
+  gainmod !== undefined && chain.push(getWorklet(ac, 'gainmod-processor', { speed: gainmod, cps, cycle }));
 
   compressorThreshold !== undefined &&
     chain.push(

--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -261,7 +261,6 @@ export function resetGlobalEffects() {
 }
 
 export const superdough = async (value, t, hapDuration, cps, cycle) => {
-  console.log({ cps, cycle });
   const ac = getAudioContext();
   if (typeof value !== 'object') {
     throw new Error(
@@ -282,6 +281,8 @@ export const superdough = async (value, t, hapDuration, cps, cycle) => {
   }
   // destructure
   let {
+    amdepth = 1,
+    amshape = 'tri',
     s = 'triangle',
     bank,
     source,
@@ -326,6 +327,7 @@ export const superdough = async (value, t, hapDuration, cps, cycle) => {
     gainmod,
     crush,
     shape,
+
     shapevol = 1,
     distort,
     distortvol = 1,
@@ -472,7 +474,16 @@ export const superdough = async (value, t, hapDuration, cps, cycle) => {
   crush !== undefined && chain.push(getWorklet(ac, 'crush-processor', { crush }));
   shape !== undefined && chain.push(getWorklet(ac, 'shape-processor', { shape, postgain: shapevol }));
   distort !== undefined && chain.push(getWorklet(ac, 'distort-processor', { distort, postgain: distortvol }));
-  gainmod !== undefined && chain.push(getWorklet(ac, 'gainmod-processor', { speed: gainmod, cps, cycle }));
+  gainmod !== undefined &&
+    chain.push(
+      getWorklet(ac, 'gainmod-processor', {
+        speed: gainmod,
+        // depth: amdepth, shape: amshape,
+
+        cps,
+        cycle,
+      }),
+    );
 
   compressorThreshold !== undefined &&
     chain.push(

--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -281,8 +281,10 @@ export const superdough = async (value, t, hapDuration, cps, cycle) => {
   }
   // destructure
   let {
+    am,
     amdepth = 1,
-    amshape = 'tri',
+    amskew = 0.5,
+    amphase = 0,
     s = 'triangle',
     bank,
     source,
@@ -324,7 +326,7 @@ export const superdough = async (value, t, hapDuration, cps, cycle) => {
     phasercenter,
     //
     coarse,
-    am,
+
     crush,
     shape,
 
@@ -479,6 +481,8 @@ export const superdough = async (value, t, hapDuration, cps, cycle) => {
       getWorklet(ac, 'am-processor', {
         speed: am,
         depth: amdepth,
+        skew: amskew,
+        phaseoffset: amphase,
         // shape: amshape,
 
         cps,

--- a/packages/superdough/worklets.mjs
+++ b/packages/superdough/worklets.mjs
@@ -109,7 +109,7 @@ class AMProcessor extends AudioWorkletProcessor {
     const depth = parameters['depth'][0];
     const skew = parameters['skew'][0];
     const phaseoffset = parameters['phaseoffset'][0];
-    const blockSize = 128;
+
     const frequency = speed * cps;
     if (this.phase == null) {
       const secondsPassed = cycle / cps;

--- a/packages/superdough/worklets.mjs
+++ b/packages/superdough/worklets.mjs
@@ -128,14 +128,14 @@ class CrushProcessor extends AudioWorkletProcessor {
 }
 registerProcessor('crush-processor', CrushProcessor);
 
-class GainModProcessor extends AudioWorkletProcessor {
+class AMProcessor extends AudioWorkletProcessor {
   static get parameterDescriptors() {
     return [
       { name: 'cps', defaultValue: 0.5 },
       { name: 'speed', defaultValue: 0.5 },
       { name: 'cycle', defaultValue: 0 },
       // { name: 'shape', defaultValue: 'tri' },
-      // { name: 'depth', defaultValue: 1 },
+      { name: 'depth', defaultValue: 1 },
     ];
   }
 
@@ -155,6 +155,7 @@ class GainModProcessor extends AudioWorkletProcessor {
     const speed = parameters['speed'][0];
     const cps = parameters['cps'][0];
     const cycle = parameters['cycle'][0];
+    const depth = clamp(parameters['depth'][0], 0, 1);
 
     const blockSize = 128;
     const frequency = speed * cps;
@@ -169,7 +170,7 @@ class GainModProcessor extends AudioWorkletProcessor {
     const dt = frequency / sampleRate;
     for (let n = 0; n < blockSize; n++) {
       for (let i = 0; i < input.length; i++) {
-        const modval = waveshapes.tri(this.phase, 0.99);
+        const modval = waveshapes.tri(this.phase, 0.99) * depth + (1 - depth);
 
         output[i][n] = input[i][n] * modval;
       }
@@ -178,7 +179,7 @@ class GainModProcessor extends AudioWorkletProcessor {
     return true;
   }
 }
-registerProcessor('gainmod-processor', GainModProcessor);
+registerProcessor('am-processor', AMProcessor);
 
 class ShapeProcessor extends AudioWorkletProcessor {
   static get parameterDescriptors() {

--- a/packages/superdough/worklets.mjs
+++ b/packages/superdough/worklets.mjs
@@ -106,23 +106,21 @@ class GainModProcessor extends AudioWorkletProcessor {
   }
 
   process(inputs, outputs, parameters) {
-    const input = inputs[0];
-    const output = outputs[0];
-    const blockSize = 128;
-
-    let crush = parameters.crush[0] ?? 8;
-    crush = Math.max(1, crush);
-
-    if (input[0] == null || output[0] == null) {
-      return false;
-    }
-    for (let n = 0; n < blockSize; n++) {
-      for (let i = 0; i < input.length; i++) {
-        const x = Math.pow(2, crush - 1);
-        output[i][n] = Math.round(input[i][n] * x) / x;
-      }
-    }
-    return true;
+    // const input = inputs[0];
+    // const output = outputs[0];
+    // const blockSize = 128;
+    // let crush = parameters.crush[0] ?? 8;
+    // crush = Math.max(1, crush);
+    // if (input[0] == null || output[0] == null) {
+    //   return false;
+    // }
+    // for (let n = 0; n < blockSize; n++) {
+    //   for (let i = 0; i < input.length; i++) {
+    //     const x = Math.pow(2, crush - 1);
+    //     output[i][n] = Math.round(input[i][n] * x) / x;
+    //   }
+    // }
+    // return true;
   }
 }
 registerProcessor('gainmod-processor', GainModProcessor);

--- a/packages/superdough/worklets.mjs
+++ b/packages/superdough/worklets.mjs
@@ -91,6 +91,14 @@ class CrushProcessor extends AudioWorkletProcessor {
   }
 }
 registerProcessor('crush-processor', CrushProcessor);
+const sine = (phase, dt) => {
+  return Math.sin(Math.PI * 2 * phase);
+
+  // return Math.sin(phase);
+};
+const getModulator = (frequency, values, ct) => {
+  Math.sin();
+};
 
 class GainModProcessor extends AudioWorkletProcessor {
   static get parameterDescriptors() {
@@ -103,23 +111,44 @@ class GainModProcessor extends AudioWorkletProcessor {
 
   constructor() {
     super();
+    this.phase;
+    this.inc = 0;
+  }
+
+  incrementPhase(dt) {
+    this.phase += dt;
+    if (this.phase > 1.0) {
+      this.phase = this.phase - 1;
+    }
   }
 
   process(inputs, outputs, parameters) {
-    // const input = inputs[0];
-    // const output = outputs[0];
-    // const blockSize = 128;
+    const speed = parameters['speed'][0];
+    const cps = parameters['cps'][0];
+    const cycle = parameters['cycle'][0];
+    const frequency = speed * cps;
+    if (this.phase == null) {
+      this.phase = (cycle * cps * frequency) % 1;
+    }
+
+    const input = inputs[0];
+    const output = outputs[0];
+    const blockSize = 128;
     // let crush = parameters.crush[0] ?? 8;
     // crush = Math.max(1, crush);
     // if (input[0] == null || output[0] == null) {
     //   return false;
     // }
-    // for (let n = 0; n < blockSize; n++) {
-    //   for (let i = 0; i < input.length; i++) {
-    //     const x = Math.pow(2, crush - 1);
-    //     output[i][n] = Math.round(input[i][n] * x) / x;
-    //   }
-    // }
+    const dt = frequency / sampleRate;
+    for (let n = 0; n < blockSize; n++) {
+      for (let i = 0; i < input.length; i++) {
+        const modval = sine(this.phase, dt);
+
+        output[i][n] = input[i][n] * modval;
+      }
+      this.incrementPhase(dt);
+      this.inc += 1;
+    }
     // return true;
   }
 }

--- a/packages/webaudio/webaudio.mjs
+++ b/packages/webaudio/webaudio.mjs
@@ -17,9 +17,9 @@ const hap2value = (hap) => {
 
 export const webaudioOutputTrigger = (t, hap, ct, cps) => superdough(hap2value(hap), t - ct, hap.duration / cps, cps);
 // uses more precise, absolute t if available, see https://github.com/tidalcycles/strudel/pull/1004
-export const webaudioOutput = (hap, deadline, hapDuration, cps, t) =>
-  superdough(hap2value(hap), t ? `=${t}` : deadline, hapDuration);
-
+export const webaudioOutput = (hap, deadline, hapDuration, cps, t, cycle) => {
+  return superdough(hap2value(hap), t ? `=${t}` : deadline, hapDuration, cps, cycle);
+};
 Pattern.prototype.webaudio = function () {
   return this.onTrigger(webaudioOutputTrigger);
 };
@@ -30,6 +30,7 @@ export function webaudioScheduler(options = {}) {
     defaultOutput: webaudioOutput,
     ...options,
   };
+
   const { defaultOutput, getTime } = options;
   return new strudel.Cyclist({
     ...options,


### PR DESCRIPTION
This pattern could be used as the basis for all kinds of interesting modulations.

An example: 
`$: note("{f g c d}%16".add("{12 7 0}%16")).am("<4 2 16 8>").amskew("<.5 1 0>").s("sawtooth")`

The timing of the modulation for the non-synced clock is a little off, and I haven't been able to figure out why yet. Maybe @felixroos you might have an idea? The synced clock timing is accurate.