### PR TITLE
Samples tab improvements

### DIFF
--- a/website/src/repl/panel/ImportSoundsButton.jsx
+++ b/website/src/repl/panel/ImportSoundsButton.jsx
@@ -10,6 +10,7 @@ export default function ImportSoundsButton({ onComplete }) {
       return;
     }
     setIsUploading(true);
+
     await uploadSamplesToDB(userSamplesDBConfig, fileUploadRef.current.files).then(() => {
       registerSamplesFromDB(userSamplesDBConfig, () => {
         onComplete();
@@ -32,7 +33,7 @@ export default function ImportSoundsButton({ onComplete }) {
         directory=""
         webkitdirectory=""
         multiple
-        accept="audio/*"
+        accept="audio/*, .wav, .mp3, .m4a, .flac"
         onChange={() => {
           onChange();
         }}

--- a/website/src/repl/panel/SoundsTab.jsx
+++ b/website/src/repl/panel/SoundsTab.jsx
@@ -13,7 +13,9 @@ export function SoundsTab() {
   const sounds = useStore(soundMap);
   const { soundsFilter } = useSettings();
   const soundEntries = useMemo(() => {
-    let filtered = Object.entries(sounds).filter(([key]) => !key.startsWith('_'));
+    let filtered = Object.entries(sounds)
+      .filter(([key]) => !key.startsWith('_'))
+      .sort((a, b) => a[0].localeCompare(b[0]));
     if (!sounds) {
       return [];
     }
@@ -43,7 +45,7 @@ export function SoundsTab() {
   });
   return (
     <div id="sounds-tab" className="px-4 flex flex-col w-full h-full dark:text-white text-stone-900">
-      <div className="pb-2 flex shrink-0 overflow-auto">
+      <div className="pb-2 flex shrink-0 flex-wrap">
         <ButtonGroup
           value={soundsFilter}
           onChange={(value) => settingsMap.setKey('soundsFilter', value)}


### PR DESCRIPTION
-Allows users to select individual files on browsers that do not support folder uploads (safari and ios). This can be expanded upon later to allow uploading either/or 

-samples are now sorted alphabetically 
-import sounds button wraps to next line on too-small screens instead of getting cropped out


