### PR TITLE
fix little dub tune example

### DIFF
--- a/website/src/pages/workshop/first-effects.mdx
+++ b/website/src/pages/workshop/first-effects.mdx
@@ -205,7 +205,7 @@ note("[~ [<[d3,a3,f4]!2 [d3,bb3,g4]!2> ~]]*2")
 sound("<bd rim>").bank("RolandTR707").delay(.5),
 n("<4 [3@3 4] [<2 0> ~@16] ~>")
 .scale("D4:minor").sound("gm_accordion:2")
-room(2).gain(.5)
+.room(2).gain(.5)
 )`}
 />
 


### PR DESCRIPTION
The dub tune example from the worshop's effects page is missing a `.` before the `room` effect.
![dub-tune](https://github.com/tidalcycles/strudel/assets/473203/5a948ce8-96d3-4437-969e-a99d4ec9249c)
