### PR TITLE
add strudelMirror to scope

### DIFF
--- a/packages/codemirror/codemirror.mjs
+++ b/packages/codemirror/codemirror.mjs
@@ -356,7 +356,6 @@ export class StrudelMirror {
     this.setCode(this.code + code);
     this.setCursorLocation(cursor);
   }
-  
 }
 
 function parseBooleans(value) {

--- a/packages/codemirror/codemirror.mjs
+++ b/packages/codemirror/codemirror.mjs
@@ -345,6 +345,18 @@ export class StrudelMirror {
   clear() {
     this.onStartRepl && document.removeEventListener('start-repl', this.onStartRepl);
   }
+  getCursorLocation() {
+    return this.editor.state.selection.main.head;
+  }
+  setCursorLocation(col) {
+    return this.editor.dispatch({ selection: { anchor: col } });
+  }
+  appendCode(code) {
+    const cursor = this.getCursorLocation();
+    this.setCode(this.code + code);
+    this.setCursorLocation(cursor);
+  }
+  
 }
 
 function parseBooleans(value) {

--- a/website/src/repl/Repl.jsx
+++ b/website/src/repl/Repl.jsx
@@ -114,6 +114,7 @@ export function Repl({ embedded = false }) {
       },
       bgFill: false,
     });
+    window.strudelMirror = editor;
 
     // init settings
 


### PR DESCRIPTION
unleashes codemirror access to the user..

fixes https://github.com/tidalcycles/strudel/issues/1063

`strudelMirror` now contains the `StrudelMirror` instance..

also added `getCursorLocation`, `setCursorLocation`, `appendCode`. These, together with `setCode` can be used to do very weird things...