### PR TITLE
fix: use full repl in web package

### DIFF
--- a/packages/web/web.mjs
+++ b/packages/web/web.mjs
@@ -6,9 +6,9 @@ export * from '@strudel/mini';
 export * from '@strudel/tonal';
 export * from '@strudel/webaudio';
 import { Pattern, evalScope, setTime } from '@strudel/core';
-import { initAudioOnFirstClick, registerSynthSounds, webaudioScheduler } from '@strudel/webaudio';
+import { initAudioOnFirstClick, registerSynthSounds, webaudioRepl } from '@strudel/webaudio';
 // import { registerSoundfonts } from '@strudel/soundfonts';
-import { evaluate as _evaluate } from '@strudel/transpiler';
+import { evaluate as _evaluate, transpiler } from '@strudel/transpiler';
 import { miniAllStrings } from '@strudel/mini';
 
 // init logic
@@ -27,19 +27,18 @@ export async function defaultPrebake() {
 // when this function finishes, everything is initialized
 let initDone;
 
-let scheduler;
+let repl;
 export function initStrudel(options = {}) {
   initAudioOnFirstClick();
-  miniAllStrings();
-  const { prebake, ...schedulerOptions } = options;
-
-  scheduler = webaudioScheduler(schedulerOptions);
+  options.miniAllStrings !== false && miniAllStrings();
+  const { prebake, ...replOptions } = options;
+  repl = webaudioRepl({ ...replOptions, transpiler });
   initDone = (async () => {
     await defaultPrebake();
     await prebake?.();
-    return scheduler;
+    return repl;
   })();
-  setTime(() => scheduler.now());
+  setTime(() => repl.scheduler.now());
   return initDone;
 }
 
@@ -47,22 +46,21 @@ window.initStrudel = initStrudel;
 
 // this method will play the pattern on the default scheduler
 Pattern.prototype.play = function () {
-  if (!scheduler) {
-    throw new Error('.play: no scheduler found. Have you called init?');
+  if (!repl) {
+    throw new Error('.play: no repl found. Have you called initStrudel?');
   }
   initDone.then(() => {
-    scheduler.setPattern(this, true);
+    repl.setPattern(this, true);
   });
   return this;
 };
 
 // stop playback
 export function hush() {
-  scheduler.stop();
+  repl.stop();
 }
 
 // evaluate and play the given code using the transpiler
 export async function evaluate(code, autoplay = true) {
-  const { pattern } = await _evaluate(code);
-  autoplay && pattern.play();
+  return repl.evaluate(code, autoplay);
 }

--- a/packages/webaudio/webaudio.mjs
+++ b/packages/webaudio/webaudio.mjs
@@ -6,7 +6,7 @@ This program is free software: you can redistribute it and/or modify it under th
 
 import * as strudel from '@strudel/core';
 import { superdough, getAudioContext, setLogger, doughTrigger } from 'superdough';
-const { Pattern, logger } = strudel;
+const { Pattern, logger, repl } = strudel;
 
 setLogger(logger);
 
@@ -24,17 +24,13 @@ Pattern.prototype.webaudio = function () {
   return this.onTrigger(webaudioOutputTrigger);
 };
 
-export function webaudioScheduler(options = {}) {
+export function webaudioRepl(options = {}) {
   options = {
     getTime: () => getAudioContext().currentTime,
     defaultOutput: webaudioOutput,
     ...options,
   };
-  const { defaultOutput, getTime } = options;
-  return new strudel.Cyclist({
-    ...options,
-    onTrigger: strudel.getTrigger({ defaultOutput, getTime }),
-  });
+  return repl(options);
 }
 
 Pattern.prototype.dough = function () {

--- a/undocumented.json
+++ b/undocumented.json
@@ -649,7 +649,7 @@
   "/packages/webaudio/webaudio.mjs": [
     "webaudioOutputTrigger",
     "webaudioOutput",
-    "webaudioScheduler"
+    "webaudioRepl"
   ],
   "/packages/webaudio/scope.mjs": [
     "drawTimeScope",


### PR DESCRIPTION
the `@strudel/web` package now uses `repl` instead of just the scheduler to support all the features like labeled statements and setcps etc..