### PR TITLE
Fix clock worker dependency path in module builds

### DIFF
--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -4,6 +4,7 @@ import { resolve } from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [],
   build: {
     lib: {

--- a/packages/repl/vite.config.js
+++ b/packages/repl/vite.config.js
@@ -6,6 +6,7 @@ import replace from '@rollup/plugin-replace';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [],
   build: {
     lib: {

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -5,6 +5,7 @@ import replace from '@rollup/plugin-replace';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [],
   build: {
     lib: {


### PR DESCRIPTION
The neocyclist clock worker import (added in 1.1.0) doesn't work in individually-published modules. When bundling those modules for publication, Vite transforms the clock worker import to the following, which is incorrect:
```
new SharedWorker(new URL("/assets/clockworker--4w5RvGG.js", import.meta.url))
```
It should be `"./assets/..."` so that it resolves relative to the package script, rather than the root url. This causes two separate issues:

* When used from a CDN, starting Strudel core works when started by default, but fails when started with `{ sync: true }`, because it's trying to load the web worker from the root of the CDN (eg https://unpkg.com/assets/clockworker--4w5RvGG.js)
* Worse, this seems to completely prevent these packages from being used by another bundler if that bundler parses URL constructors during build in order to find worker dependencies. This causes a build failure in Parcel, at least, and I would imagine it similarly affects Vite and others.

This affects the `@strudel/core` package and the other two packages which re-package the core (`@strudel/repl` and `@strudel/web`). Specifying "./" as the base path for these packages solves the problem. Diffing the dist files verified that this change didn't have any other consequences for the build.