### PR TITLE
export comment commands

### DIFF
--- a/packages/codemirror/codemirror.mjs
+++ b/packages/codemirror/codemirror.mjs
@@ -1,4 +1,5 @@
 import { closeBrackets } from '@codemirror/autocomplete';
+export { toggleComment, toggleBlockComment, toggleLineComment, toggleBlockCommentByLine } from '@codemirror/commands';
 // import { search, highlightSelectionMatches } from '@codemirror/search';
 import { history } from '@codemirror/commands';
 import { javascript } from '@codemirror/lang-javascript';


### PR DESCRIPTION
exports potentially helpful codemirror commands to the global scope:

- toggleComment
- toggleBlockComment
- toggleLineComment
- toggleBlockCommentByLine

this allows writing custom keybindings, for example:

```js
window.keyhandler && document.removeEventListener('keypress',window.keyhandler)
window.keyhandler = (e) => {
  e.key === '7' && e.ctrlKey && toggleComment(strudelMirror.editor)
}
document.addEventListener('keypress', window.keyhandler)
```