### PR TITLE
Make phaser control consistent with superdirt

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -454,9 +454,6 @@ export const { drive } = registerControl('drive');
  */
 export const { channels, ch } = registerControl('channels', 'ch');
 
-// superdirt only
-export const { phaserrate, phasr } = registerControl('phaserrate', 'phasr');
-
 /**
  * Phaser audio effect that approximates popular guitar pedals.
  *
@@ -468,7 +465,7 @@ export const { phaserrate, phasr } = registerControl('phaserrate', 'phasr');
  * .phaser("<1 2 4 8>")
  *
  */
-export const { phaser, ph } = registerControl(['phaser', 'phaserdepth', 'phasercenter', 'phasersweep'], 'ph');
+export const { phaserrate, ph, phaser } = registerControl(['phaserrate', 'phaserdepth', 'phasercenter', 'phasersweep'], 'ph', 'phaser');
 
 /**
  * The frequency sweep range of the lfo for the phaser effect. Defaults to 2000

--- a/packages/osc/osc.mjs
+++ b/packages/osc/osc.mjs
@@ -64,7 +64,6 @@ export async function oscTrigger(t_deprecate, hap, currentTime, cps = 1, targetT
   const osc = await connect();
   const controls = parseControlsFromHap(hap, cps);
   const keyvals = Object.entries(controls).flat();
-
   const ts = Math.round(collator.calculateTimestamp(currentTime, targetTime) * 1000);
   const message = new OSC.Message('/dirt/play', ...keyvals);
   const bundle = new OSC.Bundle([message], ts);

--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -375,7 +375,7 @@ export const superdough = async (value, t, hapDuration) => {
     bandq = getDefaultValue('bandq'),
     channels = getDefaultValue('channels'),
     //phaser
-    phaser,
+    phaserrate: phaser,
     phaserdepth = getDefaultValue('phaserdepth'),
     phasersweep,
     phasercenter,


### PR DESCRIPTION
make "phaser" an alternative control name for "phaserrate" (which is used in superdirt). no patterns will be affected by this update as "phaser" works also.