### PR TITLE
Revert "Make phaser control consistent with superdirt"

### DIFF
--- a/packages/core/controls.mjs
+++ b/packages/core/controls.mjs
@@ -454,6 +454,9 @@ export const { drive } = registerControl('drive');
  */
 export const { channels, ch } = registerControl('channels', 'ch');
 
+// superdirt only
+export const { phaserrate, phasr } = registerControl('phaserrate', 'phasr');
+
 /**
  * Phaser audio effect that approximates popular guitar pedals.
  *
@@ -465,7 +468,7 @@ export const { channels, ch } = registerControl('channels', 'ch');
  * .phaser("<1 2 4 8>")
  *
  */
-export const { phaserrate, ph, phaser } = registerControl(['phaserrate', 'phaserdepth', 'phasercenter', 'phasersweep'], 'ph', 'phaser');
+export const { phaser, ph } = registerControl(['phaser', 'phaserdepth', 'phasercenter', 'phasersweep'], 'ph');
 
 /**
  * The frequency sweep range of the lfo for the phaser effect. Defaults to 2000

--- a/packages/osc/osc.mjs
+++ b/packages/osc/osc.mjs
@@ -64,6 +64,7 @@ export async function oscTrigger(t_deprecate, hap, currentTime, cps = 1, targetT
   const osc = await connect();
   const controls = parseControlsFromHap(hap, cps);
   const keyvals = Object.entries(controls).flat();
+
   const ts = Math.round(collator.calculateTimestamp(currentTime, targetTime) * 1000);
   const message = new OSC.Message('/dirt/play', ...keyvals);
   const bundle = new OSC.Bundle([message], ts);

--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -375,7 +375,7 @@ export const superdough = async (value, t, hapDuration) => {
     bandq = getDefaultValue('bandq'),
     channels = getDefaultValue('channels'),
     //phaser
-    phaserrate: phaser,
+    phaser,
     phaserdepth = getDefaultValue('phaserdepth'),
     phasersweep,
     phasercenter,


### PR DESCRIPTION
Reverts tidalcycles/strudel#1178
prettier build error