### PR TITLE
Add seqPLoop from Tidal

### DIFF
--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -1430,6 +1430,36 @@ export function arrange(...sections) {
   return s_cat(...sections).slow(total);
 }
 
+/**
+ * Similarly to `arrange`, allows you to arrange multiple patterns together over multiple cycles.
+ * Unlike `arrange`, you specify a start and stop time for each pattern rather than duration, which
+ * means that patterns can overlap.
+ * @return {Pattern}
+ * @example
+seqPLoop([0, 2, "bd(3,8)"],
+         [1, 3, "cp(3,8)"]
+        )
+  .sound()
+ */
+export function seqPLoop(...parts) {
+  let total = Fraction(0);
+  const pats = [];
+  for (let part of parts) {
+    if (part.length == 2) {
+      part.unshift(total);
+    }
+    total = part[1];
+  }
+
+  return stack(
+    ...parts.map(([start, stop, pat]) =>
+      pure(reify(pat)).compress(Fraction(start).div(total), Fraction(stop).div(total)),
+    ),
+  )
+    .slow(total)
+    .innerJoin(); // or resetJoin or restartJoin ??
+}
+
 export function fastcat(...pats) {
   let result = slowcat(...pats);
   if (pats.length > 1) {

--- a/test/__snapshots__/examples.test.mjs.snap
+++ b/test/__snapshots__/examples.test.mjs.snap
@@ -6850,6 +6850,26 @@ exports[`runs examples > example "seq" example index 0 2`] = `
 ]
 `;
 
+exports[`runs examples > example "seqPLoop" example index 0 1`] = `
+[
+  "[ 0/1 → 1/8 | s:bd ]",
+  "[ 3/8 → 1/2 | s:bd ]",
+  "[ 3/4 → 7/8 | s:bd ]",
+  "[ 1/1 → 9/8 | s:bd ]",
+  "[ 1/1 → 9/8 | s:cp ]",
+  "[ 11/8 → 3/2 | s:bd ]",
+  "[ 11/8 → 3/2 | s:cp ]",
+  "[ 7/4 → 15/8 | s:bd ]",
+  "[ 7/4 → 15/8 | s:cp ]",
+  "[ 2/1 → 17/8 | s:cp ]",
+  "[ 19/8 → 5/2 | s:cp ]",
+  "[ 11/4 → 23/8 | s:cp ]",
+  "[ 3/1 → 25/8 | s:bd ]",
+  "[ 27/8 → 7/2 | s:bd ]",
+  "[ 15/4 → 31/8 | s:bd ]",
+]
+`;
+
 exports[`runs examples > example "shape" example index 0 1`] = `
 [
   "[ 0/1 → 1/8 | s:hh shape:0 ]",


### PR DESCRIPTION
Ref #31 - add function for composing patterns together with start/stop times.

It hasn't got the best name, and overlaps with `arrange`, this could do with tidying up in the future. It would also be nice to be able to use different joins (resetJoin/restartJoin).