### PR TITLE
remove redundant example for cat, update snapshot

### DIFF
--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -809,15 +809,6 @@ export class Pattern {
   //////////////////////////////////////////////////////////////////////
   // Multi-pattern functions
 
-  /**
-   * Stacks the given pattern(s) to the current pattern.
-   * @name stack
-   * @memberof Pattern
-   * @example
-   * s("hh*4").stack(
-   *   note("c4(5,8)")
-   * )
-   */
   stack(...pats) {
     return stack(this, ...pats);
   }
@@ -1254,11 +1245,18 @@ export function reify(thing) {
 
 /** The given items are played at the same time at the same length.
  *
+ * @name stack
  * @return {Pattern}
  * @synonyms polyrhythm, pr
  * @example
  * stack("g3", "b3", ["e4", "d4"]).note()
  * // "g3,b3,[e4,d4]".note()
+ *
+ * @example
+ * // As a chained function:
+ * s("hh*4").stack(
+ *   note("c4(5,8)")
+ * )
  */
 export function stack(...pats) {
   // Array test here is to avoid infinite recursions..
@@ -1380,14 +1378,16 @@ export function slowcatPrime(...pats) {
 
 /** The given items are con**cat**enated, where each one takes one cycle.
  *
+ * @name cat
  * @param {...any} items - The items to concatenate
  * @synonyms slowcat
  * @return {Pattern}
  * @example
  * cat("e5", "b4", ["d5", "c5"]).note()
  * // "<e5 b4 [d5 c5]>".note()
+ *
  * @example
- * // You can also use cat as a chained function like this:
+ * // As a chained function:
  * s("hh*4").cat(
  *    note("c4(5,8)")
  * )
@@ -1468,7 +1468,8 @@ export function sequence(...pats) {
  * seq("e5", "b4", ["d5", "c5"]).note()
  * // "e5 b4 [d5 c5]".note()
  *
- * // Or as a chained function:
+ * @example
+ * // As a chained function:
  * s("hh*4").seq(
  *   note("c4(5,8)")
  * )

--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -839,17 +839,6 @@ export class Pattern {
   seq(...pats) {
     return sequence(this, ...pats);
   }
-
-  /**
-   * Appends the given pattern(s) to the next cycle.
-   * @name cat
-   * @memberof Pattern
-   * @synonyms slowcat
-   * @example
-   * s("hh*4").cat(
-   *   note("c4(5,8)")
-   * )
-   */
   cat(...pats) {
     return cat(this, ...pats);
   }

--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -1396,7 +1396,11 @@ export function slowcatPrime(...pats) {
  * @example
  * cat("e5", "b4", ["d5", "c5"]).note()
  * // "<e5 b4 [d5 c5]>".note()
- *
+ * @example
+ * // You can also use cat as a chained function like this:
+ * s("hh*4").cat(
+ *    note("c4(5,8)")
+ * )
  */
 export function cat(...pats) {
   return slowcat(...pats);

--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -1245,7 +1245,6 @@ export function reify(thing) {
 
 /** The given items are played at the same time at the same length.
  *
- * @name stack
  * @return {Pattern}
  * @synonyms polyrhythm, pr
  * @example
@@ -1378,7 +1377,6 @@ export function slowcatPrime(...pats) {
 
 /** The given items are con**cat**enated, where each one takes one cycle.
  *
- * @name cat
  * @param {...any} items - The items to concatenate
  * @synonyms slowcat
  * @return {Pattern}
@@ -1461,8 +1459,6 @@ export function sequence(...pats) {
 }
 
 /** Like **cat**, but the items are crammed into one cycle.
- * @name seq
- * @memberof Pattern
  * @synonyms sequence, fastcat
  * @example
  * seq("e5", "b4", ["d5", "c5"]).note()

--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -826,16 +826,6 @@ export class Pattern {
     return sequence(this, ...pats);
   }
 
-  /**
-   * Appends the given pattern(s) to the current pattern.
-   * @name seq
-   * @memberof Pattern
-   * @synonyms sequence, fastcat
-   * @example
-   * s("hh*4").seq(
-   *   note("c4(5,8)")
-   * )
-   */
   seq(...pats) {
     return sequence(this, ...pats);
   }
@@ -1471,12 +1461,19 @@ export function sequence(...pats) {
 }
 
 /** Like **cat**, but the items are crammed into one cycle.
- * @synonyms fastcat, sequence
+ * @name seq
+ * @memberof Pattern
+ * @synonyms sequence, fastcat
  * @example
  * seq("e5", "b4", ["d5", "c5"]).note()
  * // "e5 b4 [d5 c5]".note()
  *
+ * // Or as a chained function:
+ * s("hh*4").seq(
+ *   note("c4(5,8)")
+ * )
  */
+
 export function seq(...pats) {
   return fastcat(...pats);
 }

--- a/test/__snapshots__/examples.test.mjs.snap
+++ b/test/__snapshots__/examples.test.mjs.snap
@@ -7016,27 +7016,6 @@ exports[`runs examples > example "seq" example index 0 1`] = `
 ]
 `;
 
-exports[`runs examples > example "seq" example index 0 2`] = `
-[
-  "[ 0/1 → 1/3 | note:e5 ]",
-  "[ 1/3 → 2/3 | note:b4 ]",
-  "[ 2/3 → 5/6 | note:d5 ]",
-  "[ 5/6 → 1/1 | note:c5 ]",
-  "[ 1/1 → 4/3 | note:e5 ]",
-  "[ 4/3 → 5/3 | note:b4 ]",
-  "[ 5/3 → 11/6 | note:d5 ]",
-  "[ 11/6 → 2/1 | note:c5 ]",
-  "[ 2/1 → 7/3 | note:e5 ]",
-  "[ 7/3 → 8/3 | note:b4 ]",
-  "[ 8/3 → 17/6 | note:d5 ]",
-  "[ 17/6 → 3/1 | note:c5 ]",
-  "[ 3/1 → 10/3 | note:e5 ]",
-  "[ 10/3 → 11/3 | note:b4 ]",
-  "[ 11/3 → 23/6 | note:d5 ]",
-  "[ 23/6 → 4/1 | note:c5 ]",
-]
-`;
-
 exports[`runs examples > example "seqPLoop" example index 0 1`] = `
 [
   "[ 0/1 → 1/8 | s:bd ]",

--- a/test/__snapshots__/examples.test.mjs.snap
+++ b/test/__snapshots__/examples.test.mjs.snap
@@ -1388,6 +1388,29 @@ exports[`runs examples > example "cat" example index 0 1`] = `
 ]
 `;
 
+exports[`runs examples > example "cat" example index 1 1`] = `
+[
+  "[ 0/1 → 1/4 | s:hh ]",
+  "[ 1/4 → 1/2 | s:hh ]",
+  "[ 1/2 → 3/4 | s:hh ]",
+  "[ 3/4 → 1/1 | s:hh ]",
+  "[ 1/1 → 9/8 | note:c4 ]",
+  "[ 5/4 → 11/8 | note:c4 ]",
+  "[ 11/8 → 3/2 | note:c4 ]",
+  "[ 13/8 → 7/4 | note:c4 ]",
+  "[ 7/4 → 15/8 | note:c4 ]",
+  "[ 2/1 → 9/4 | s:hh ]",
+  "[ 9/4 → 5/2 | s:hh ]",
+  "[ 5/2 → 11/4 | s:hh ]",
+  "[ 11/4 → 3/1 | s:hh ]",
+  "[ 3/1 → 25/8 | note:c4 ]",
+  "[ 13/4 → 27/8 | note:c4 ]",
+  "[ 27/8 → 7/2 | note:c4 ]",
+  "[ 29/8 → 15/4 | note:c4 ]",
+  "[ 15/4 → 31/8 | note:c4 ]",
+]
+`;
+
 exports[`runs examples > example "ceil" example index 0 1`] = `
 [
   "[ 0/1 → 1/4 | note:42 ]",

--- a/test/__snapshots__/examples.test.mjs.snap
+++ b/test/__snapshots__/examples.test.mjs.snap
@@ -1380,29 +1380,6 @@ exports[`runs examples > example "brandBy" example index 0 1`] = `
 
 exports[`runs examples > example "cat" example index 0 1`] = `
 [
-  "[ 0/1 → 1/4 | s:hh ]",
-  "[ 1/4 → 1/2 | s:hh ]",
-  "[ 1/2 → 3/4 | s:hh ]",
-  "[ 3/4 → 1/1 | s:hh ]",
-  "[ 1/1 → 9/8 | note:c4 ]",
-  "[ 5/4 → 11/8 | note:c4 ]",
-  "[ 11/8 → 3/2 | note:c4 ]",
-  "[ 13/8 → 7/4 | note:c4 ]",
-  "[ 7/4 → 15/8 | note:c4 ]",
-  "[ 2/1 → 9/4 | s:hh ]",
-  "[ 9/4 → 5/2 | s:hh ]",
-  "[ 5/2 → 11/4 | s:hh ]",
-  "[ 11/4 → 3/1 | s:hh ]",
-  "[ 3/1 → 25/8 | note:c4 ]",
-  "[ 13/4 → 27/8 | note:c4 ]",
-  "[ 27/8 → 7/2 | note:c4 ]",
-  "[ 29/8 → 15/4 | note:c4 ]",
-  "[ 15/4 → 31/8 | note:c4 ]",
-]
-`;
-
-exports[`runs examples > example "cat" example index 0 2`] = `
-[
   "[ 0/1 → 1/1 | note:e5 ]",
   "[ 1/1 → 2/1 | note:b4 ]",
   "[ 2/1 → 5/2 | note:d5 ]",

--- a/test/__snapshots__/examples.test.mjs.snap
+++ b/test/__snapshots__/examples.test.mjs.snap
@@ -6977,6 +6977,27 @@ exports[`runs examples > example "segment" example index 0 1`] = `
 
 exports[`runs examples > example "seq" example index 0 1`] = `
 [
+  "[ 0/1 → 1/3 | note:e5 ]",
+  "[ 1/3 → 2/3 | note:b4 ]",
+  "[ 2/3 → 5/6 | note:d5 ]",
+  "[ 5/6 → 1/1 | note:c5 ]",
+  "[ 1/1 → 4/3 | note:e5 ]",
+  "[ 4/3 → 5/3 | note:b4 ]",
+  "[ 5/3 → 11/6 | note:d5 ]",
+  "[ 11/6 → 2/1 | note:c5 ]",
+  "[ 2/1 → 7/3 | note:e5 ]",
+  "[ 7/3 → 8/3 | note:b4 ]",
+  "[ 8/3 → 17/6 | note:d5 ]",
+  "[ 17/6 → 3/1 | note:c5 ]",
+  "[ 3/1 → 10/3 | note:e5 ]",
+  "[ 10/3 → 11/3 | note:b4 ]",
+  "[ 11/3 → 23/6 | note:d5 ]",
+  "[ 23/6 → 4/1 | note:c5 ]",
+]
+`;
+
+exports[`runs examples > example "seq" example index 1 1`] = `
+[
   "[ 0/1 → 1/8 | s:hh ]",
   "[ 1/8 → 1/4 | s:hh ]",
   "[ 1/4 → 3/8 | s:hh ]",
@@ -7710,6 +7731,27 @@ exports[`runs examples > example "squiz" example index 0 1`] = `
 
 exports[`runs examples > example "stack" example index 0 1`] = `
 [
+  "[ 0/1 → 1/2 | note:e4 ]",
+  "[ 0/1 → 1/1 | note:g3 ]",
+  "[ 0/1 → 1/1 | note:b3 ]",
+  "[ 1/2 → 1/1 | note:d4 ]",
+  "[ 1/1 → 3/2 | note:e4 ]",
+  "[ 1/1 → 2/1 | note:g3 ]",
+  "[ 1/1 → 2/1 | note:b3 ]",
+  "[ 3/2 → 2/1 | note:d4 ]",
+  "[ 2/1 → 5/2 | note:e4 ]",
+  "[ 2/1 → 3/1 | note:g3 ]",
+  "[ 2/1 → 3/1 | note:b3 ]",
+  "[ 5/2 → 3/1 | note:d4 ]",
+  "[ 3/1 → 7/2 | note:e4 ]",
+  "[ 3/1 → 4/1 | note:g3 ]",
+  "[ 3/1 → 4/1 | note:b3 ]",
+  "[ 7/2 → 4/1 | note:d4 ]",
+]
+`;
+
+exports[`runs examples > example "stack" example index 1 1`] = `
+[
   "[ 0/1 → 1/8 | note:c4 ]",
   "[ 0/1 → 1/4 | s:hh ]",
   "[ 1/4 → 3/8 | note:c4 ]",
@@ -7746,27 +7788,6 @@ exports[`runs examples > example "stack" example index 0 1`] = `
   "[ 29/8 → 15/4 | note:c4 ]",
   "[ 15/4 → 31/8 | note:c4 ]",
   "[ 15/4 → 4/1 | s:hh ]",
-]
-`;
-
-exports[`runs examples > example "stack" example index 0 2`] = `
-[
-  "[ 0/1 → 1/2 | note:e4 ]",
-  "[ 0/1 → 1/1 | note:g3 ]",
-  "[ 0/1 → 1/1 | note:b3 ]",
-  "[ 1/2 → 1/1 | note:d4 ]",
-  "[ 1/1 → 3/2 | note:e4 ]",
-  "[ 1/1 → 2/1 | note:g3 ]",
-  "[ 1/1 → 2/1 | note:b3 ]",
-  "[ 3/2 → 2/1 | note:d4 ]",
-  "[ 2/1 → 5/2 | note:e4 ]",
-  "[ 2/1 → 3/1 | note:g3 ]",
-  "[ 2/1 → 3/1 | note:b3 ]",
-  "[ 5/2 → 3/1 | note:d4 ]",
-  "[ 3/1 → 7/2 | note:e4 ]",
-  "[ 3/1 → 4/1 | note:g3 ]",
-  "[ 3/1 → 4/1 | note:b3 ]",
-  "[ 7/2 → 4/1 | note:d4 ]",
 ]
 `;
 

--- a/website/src/pages/learn/factories.mdx
+++ b/website/src/pages/learn/factories.mdx
@@ -25,25 +25,13 @@ These are the equivalents used by the Mini Notation:
 
 <JsDoc client:idle name="cat" h={0} />
 
-You can also use cat as a chained function like this:
-
-<JsDoc client:idle name="Pattern.cat" h={0} hideDescription />
-
 ## seq
 
 <JsDoc client:idle name="seq" h={0} />
 
-Or as a chained function:
-
-<JsDoc client:idle name="Pattern.seq" h={0} hideDescription />
-
 ## stack
 
 <JsDoc client:idle name="stack" h={0} />
-
-As a chained function:
-
-<JsDoc client:idle name="Pattern.stack" h={0} hideDescription />
 
 ## s_cat
 


### PR DESCRIPTION
This PR is for issue  #1186

`cat` was documented twice causing it to appear twice in the API reference. This change removes the less descriptive example and keeps the other one. 

![image](https://github.com/user-attachments/assets/705d4dc9-373e-4808-856e-607ff6df8d56)
