### PR TITLE
Apply `all` function to individual patterns rather than final stack

### DIFF
--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -152,9 +152,12 @@ export function repl({
       shouldHush && hush();
       let { pattern, meta } = await _evaluate(code, transpiler, transpilerOptions);
       if (Object.keys(pPatterns).length) {
-        pattern = stack(...Object.values(pPatterns));
-      }
-      if (allTransform) {
+        let patterns = Object.values(pPatterns);
+        if (allTransform) {
+          patterns = patterns.map(allTransform);
+        }
+        pattern = stack(...patterns);
+      } else if (allTransform) {
         pattern = allTransform(pattern);
       }
       if (!isPattern(pattern)) {


### PR DESCRIPTION
This fixes `all` to work with 'pulsewise' functions.