### PR TITLE
REPL: solo and sync configuration

### DIFF
--- a/packages/codemirror/codemirror.mjs
+++ b/packages/codemirror/codemirror.mjs
@@ -133,6 +133,7 @@ export class StrudelMirror {
       autodraw,
       prebake,
       bgFill = true,
+      solo = true,
       ...replOptions
     } = options;
     this.code = initialCode;
@@ -143,6 +144,7 @@ export class StrudelMirror {
     this.drawContext = drawContext;
     this.onDraw = onDraw || this.draw;
     this.id = id || s4();
+    this.solo = solo;
 
     this.drawer = new Drawer((haps, time, _, painters) => {
       const currentFrame = haps.filter((hap) => hap.isActive(time));
@@ -159,12 +161,14 @@ export class StrudelMirror {
         replOptions?.onToggle?.(started);
         if (started) {
           this.drawer.start(this.repl.scheduler);
-          // stop other repls when this one is started
-          document.dispatchEvent(
-            new CustomEvent('start-repl', {
-              detail: this.id,
-            }),
-          );
+          if (this.solo) {
+            // stop other repls when this one is started
+            document.dispatchEvent(
+              new CustomEvent('start-repl', {
+                detail: this.id,
+              }),
+            );
+          }
         } else {
           this.drawer.stop();
           updateMiniLocations(this.editor, []);
@@ -219,7 +223,7 @@ export class StrudelMirror {
 
     // stop this repl when another repl is started
     this.onStartRepl = (e) => {
-      if (e.detail !== this.id) {
+      if (this.solo && e.detail !== this.id) {
         this.stop();
       }
     };

--- a/packages/repl/repl-component.mjs
+++ b/packages/repl/repl-component.mjs
@@ -51,8 +51,8 @@ if (typeof HTMLElement !== 'undefined') {
           });
           this.dispatchEvent(event);
         },
-       solo: this.solo,
-       sync: this.sync,
+        solo: this.solo,
+        sync: this.sync,
       });
       // init settings
       this.editor.updateSettings(this.settings);

--- a/packages/repl/repl-component.mjs
+++ b/packages/repl/repl-component.mjs
@@ -10,6 +10,8 @@ if (typeof HTMLElement !== 'undefined') {
     static observedAttributes = ['code'];
     settings = codemirrorSettings.get();
     editor = null;
+    sync = false;
+    solo = true;
     constructor() {
       super();
     }
@@ -49,6 +51,8 @@ if (typeof HTMLElement !== 'undefined') {
           });
           this.dispatchEvent(event);
         },
+       solo: this.solo,
+       sync: this.sync,
       });
       // init settings
       this.editor.updateSettings(this.settings);


### PR DESCRIPTION
Those changes are to open a configuration path through the `@strudel/repl` package to existing implementations for controlling whether multiple REPLs:
- play in sync
- and simultaneously

[Relevant Discord message](https://discord.com/channels/779427371270275082/1191011773311107153/1304814716970864742)
