### PR TITLE
add formatting shortcut to use prettier

### DIFF
--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -49,7 +49,8 @@
     "@strudel/transpiler": "workspace:*",
     "@uiw/codemirror-themes": "^4.21.21",
     "@uiw/codemirror-themes-all": "^4.21.21",
-    "nanostores": "^0.9.5"
+    "nanostores": "^0.9.5",
+    "prettier": "^3.3.3"
   },
   "devDependencies": {
     "vite": "^5.0.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       nanostores:
         specifier: ^0.9.5
         version: 0.9.5
+      prettier:
+        specifier: ^3.3.3
+        version: 3.3.3
     devDependencies:
       vite:
         specifier: ^5.0.10
@@ -7740,6 +7743,7 @@ packages:
 
   workbox-google-analytics@7.0.0:
     resolution: {integrity: sha512-MEYM1JTn/qiC3DbpvP2BVhyIH+dV/5BjHk756u9VbwuAhu0QHyKscTnisQuz21lfRpOwiS9z4XdqeVAKol0bzg==}
+    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
 
   workbox-navigation-preload@7.0.0:
     resolution: {integrity: sha512-juWCSrxo/fiMz3RsvDspeSLGmbgC0U9tKqcUPZBCf35s64wlaLXyn2KdHHXVQrb2cqF7I0Hc9siQalainmnXJA==}


### PR DESCRIPTION
This is for my own suggestion: https://github.com/tidalcycles/strudel/issues/1220

This adds a shortcut to codemirror, Ctrl+\, to format the document using Prettier, see [this](https://prettier.io/docs/en/browser) for how it's used in a standalone environment. Because Strudel uses mixed quotes and Prettier insists on consistent quotes, I had to use a hack to get around this, see comment in code.

Open to suggestions on the entrypoint for formatting!
- The shortcut to use (tried Ctrl+Shift+F and variations but these all do not work unfortunately, either it's mapped to something full-screen or will just be ignored and characters are entered into the editor instead)
- Whether the formatting/update and shortcut should be in codemirror, or formatting/update should happen outside codemirror, i.e. in the website with more flexibility on it being a keyboard shortcut, format button, etc.

## Before format 

<img width="893" alt="Screenshot 2024-11-23 at 6 46 59 PM" src="https://github.com/user-attachments/assets/c6cd908c-2062-4ce5-90bf-18543adc19b3">

## After format

<img width="897" alt="Screenshot 2024-11-23 at 6 47 06 PM" src="https://github.com/user-attachments/assets/f708e0f9-4c21-4e1e-b03d-9806a2f89511">
