### PR TITLE
Make `all()` post-stack again, and add `each()` for pre-stack

### DIFF
--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -168,7 +168,7 @@ export function repl({
         pattern = allTransform(pattern);
       }
       if (togetherTransform) {
-        pattern = togetherTransform(pattern)
+        pattern = togetherTransform(pattern);
       }
       if (!isPattern(pattern)) {
         const message = `got "${typeof evaluated}" instead of pattern`;

--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -63,11 +63,13 @@ export function repl({
   let pPatterns = {};
   let anonymousIndex = 0;
   let allTransform;
+  let togetherTransform;
 
   const hush = function () {
     pPatterns = {};
     anonymousIndex = 0;
     allTransform = undefined;
+    togetherTransform = undefined;
     return silence;
   };
 
@@ -86,6 +88,10 @@ export function repl({
   const setCpm = (cpm) => scheduler.setCps(cpm / 60);
   const all = function (transform) {
     allTransform = transform;
+    return silence;
+  };
+  const together = function (transform) {
+    togetherTransform = transform;
     return silence;
   };
 
@@ -131,6 +137,7 @@ export function repl({
     });
     return evalScope({
       all,
+      together,
       hush,
       cpm,
       setCps,
@@ -159,6 +166,9 @@ export function repl({
         pattern = stack(...patterns);
       } else if (allTransform) {
         pattern = allTransform(pattern);
+      }
+      if (togetherTransform) {
+        pattern = togetherTransform(pattern)
       }
       if (!isPattern(pattern)) {
         const message = `got "${typeof evaluated}" instead of pattern`;

--- a/packages/core/repl.mjs
+++ b/packages/core/repl.mjs
@@ -63,13 +63,13 @@ export function repl({
   let pPatterns = {};
   let anonymousIndex = 0;
   let allTransform;
-  let togetherTransform;
+  let eachTransform;
 
   const hush = function () {
     pPatterns = {};
     anonymousIndex = 0;
     allTransform = undefined;
-    togetherTransform = undefined;
+    eachTransform = undefined;
     return silence;
   };
 
@@ -90,8 +90,8 @@ export function repl({
     allTransform = transform;
     return silence;
   };
-  const together = function (transform) {
-    togetherTransform = transform;
+  const each = function (transform) {
+    eachTransform = transform;
     return silence;
   };
 
@@ -137,7 +137,7 @@ export function repl({
     });
     return evalScope({
       all,
-      together,
+      each,
       hush,
       cpm,
       setCps,
@@ -160,15 +160,15 @@ export function repl({
       let { pattern, meta } = await _evaluate(code, transpiler, transpilerOptions);
       if (Object.keys(pPatterns).length) {
         let patterns = Object.values(pPatterns);
-        if (allTransform) {
-          patterns = patterns.map(allTransform);
+        if (eachTransform) {
+          patterns = patterns.map(eachTransform);
         }
         pattern = stack(...patterns);
-      } else if (allTransform) {
-        pattern = allTransform(pattern);
+      } else if (eachTransform) {
+        pattern = eachTransform(pattern);
       }
-      if (togetherTransform) {
-        pattern = togetherTransform(pattern);
+      if (allTransform) {
+        pattern = allTransform(pattern);
       }
       if (!isPattern(pattern)) {
         const message = `got "${typeof evaluated}" instead of pattern`;


### PR DESCRIPTION
Since #1209 changed `all()` to be applied to patterns separately, the old 'post-stack' behaviour has been missed, for things like applying a single `.pianoroll()` to everything. This brings the old behaviour back as `.together()`.
