### PR TITLE
Bugfix: update mqtt connections dictionary

### DIFF
--- a/packages/mqtt/mqtt.mjs
+++ b/packages/mqtt/mqtt.mjs
@@ -57,6 +57,7 @@ Pattern.prototype.mqtt = function (
     cx = connections[key];
   } else {
     cx = new Paho.Client(host, client);
+    connections[key] = cx;
     cx.onConnectionLost = onConnectionLost;
     cx.onMessageArrived = onMessageArrived;
     const props = {


### PR DESCRIPTION
MQTT connections dictionary wasn't been updated, so new connections were made every evaluation.