### PR TITLE
Rename repeat back to extend

### DIFF
--- a/packages/core/pattern.mjs
+++ b/packages/core/pattern.mjs
@@ -388,7 +388,7 @@ export class Pattern {
 
   polyJoin = function () {
     const pp = this;
-    return pp.fmap((p) => p.repeat(pp._steps.div(p._steps))).outerJoin();
+    return pp.fmap((p) => p.extend(pp._steps.div(p._steps))).outerJoin();
   };
 
   polyBind(func) {
@@ -2845,16 +2845,16 @@ export const drop = stepRegister('drop', function (i, pat) {
 /**
  * *Experimental*
  *
- * `repeat` is similar to `fast` in that it 'speeds up' the pattern, but it also increases the step count
- * accordingly. So `stepcat("a b".repeat(2), "c d")` would be the same as `"a b a b c d"`, whereas
+ * `extend` is similar to `fast` in that it increases its density, but it also increases the step count
+ * accordingly. So `stepcat("a b".extend(2), "c d")` would be the same as `"a b a b c d"`, whereas
  * `stepcat("a b".fast(2), "c d")` would be the same as `"[a b] [a b] c d"`.
  * @example
  * stepcat(
- *   sound("bd bd - cp").repeat(2),
+ *   sound("bd bd - cp").extend(2),
  *   sound("bd - sd -")
  * ).pace(8)
  */
-export const repeat = stepRegister('repeat', function (factor, pat) {
+export const extend = stepRegister('extend', function (factor, pat) {
   return pat.fast(factor).expand(factor);
 });
 
@@ -3066,8 +3066,8 @@ export const s_sub = drop;
 Pattern.prototype.s_sub = Pattern.prototype.drop;
 export const s_expand = expand;
 Pattern.prototype.s_expand = Pattern.prototype.expand;
-export const s_extend = repeat;
-Pattern.prototype.s_extend = Pattern.prototype.repeat;
+export const s_extend = extend;
+Pattern.prototype.s_extend = Pattern.prototype.extend;
 export const s_contract = contract;
 Pattern.prototype.s_contract = Pattern.prototype.contract;
 export const s_tour = tour;

--- a/test/__snapshots__/examples.test.mjs.snap
+++ b/test/__snapshots__/examples.test.mjs.snap
@@ -3019,6 +3019,33 @@ exports[`runs examples > example "expand" example index 0 1`] = `
 ]
 `;
 
+exports[`runs examples > example "extend" example index 0 1`] = `
+[
+  "[ 0/1 → 1/8 | s:bd ]",
+  "[ 1/8 → 1/4 | s:bd ]",
+  "[ 3/8 → 1/2 | s:cp ]",
+  "[ 1/2 → 5/8 | s:bd ]",
+  "[ 5/8 → 3/4 | s:bd ]",
+  "[ 7/8 → 1/1 | s:cp ]",
+  "[ 1/1 → 9/8 | s:bd ]",
+  "[ 5/4 → 11/8 | s:sd ]",
+  "[ 3/2 → 13/8 | s:bd ]",
+  "[ 13/8 → 7/4 | s:bd ]",
+  "[ 15/8 → 2/1 | s:cp ]",
+  "[ 2/1 → 17/8 | s:bd ]",
+  "[ 17/8 → 9/4 | s:bd ]",
+  "[ 19/8 → 5/2 | s:cp ]",
+  "[ 5/2 → 21/8 | s:bd ]",
+  "[ 11/4 → 23/8 | s:sd ]",
+  "[ 3/1 → 25/8 | s:bd ]",
+  "[ 25/8 → 13/4 | s:bd ]",
+  "[ 27/8 → 7/2 | s:cp ]",
+  "[ 7/2 → 29/8 | s:bd ]",
+  "[ 29/8 → 15/4 | s:bd ]",
+  "[ 31/8 → 4/1 | s:cp ]",
+]
+`;
+
 exports[`runs examples > example "fanchor" example index 0 1`] = `
 [
   "[ 0/1 → 1/8 | note:f s:sawtooth cutoff:1000 lpenv:8 fanchor:0 ]",
@@ -6487,33 +6514,6 @@ exports[`runs examples > example "release" example index 0 1`] = `
   "[ 13/4 → 7/2 | note:e3 release:0.1 ]",
   "[ 7/2 → 15/4 | note:g3 release:0.1 ]",
   "[ 15/4 → 4/1 | note:c4 release:0.1 ]",
-]
-`;
-
-exports[`runs examples > example "repeat" example index 0 1`] = `
-[
-  "[ 0/1 → 1/8 | s:bd ]",
-  "[ 1/8 → 1/4 | s:bd ]",
-  "[ 3/8 → 1/2 | s:cp ]",
-  "[ 1/2 → 5/8 | s:bd ]",
-  "[ 5/8 → 3/4 | s:bd ]",
-  "[ 7/8 → 1/1 | s:cp ]",
-  "[ 1/1 → 9/8 | s:bd ]",
-  "[ 5/4 → 11/8 | s:sd ]",
-  "[ 3/2 → 13/8 | s:bd ]",
-  "[ 13/8 → 7/4 | s:bd ]",
-  "[ 15/8 → 2/1 | s:cp ]",
-  "[ 2/1 → 17/8 | s:bd ]",
-  "[ 17/8 → 9/4 | s:bd ]",
-  "[ 19/8 → 5/2 | s:cp ]",
-  "[ 5/2 → 21/8 | s:bd ]",
-  "[ 11/4 → 23/8 | s:sd ]",
-  "[ 3/1 → 25/8 | s:bd ]",
-  "[ 25/8 → 13/4 | s:bd ]",
-  "[ 27/8 → 7/2 | s:cp ]",
-  "[ 7/2 → 29/8 | s:bd ]",
-  "[ 29/8 → 15/4 | s:bd ]",
-  "[ 31/8 → 4/1 | s:cp ]",
 ]
 `;
 

--- a/website/src/pages/learn/stepwise.mdx
+++ b/website/src/pages/learn/stepwise.mdx
@@ -100,9 +100,9 @@ Earlier versions of many of these functions had `s_` prefixes, and the `pace` fu
 
 <JsDoc client:idle name="contract" h={0} />
 
-### repeat
+### extend
 
-<JsDoc client:idle name="repeat" h={0} />
+<JsDoc client:idle name="extend" h={0} />
 
 ### take
 


### PR DESCRIPTION
`repeat` was just a bad name for this, as it doesn't necessarily repeat. I tried hard to think of a word for fitting more steps into a metric cycle, but can't find one better than 'extend'.