### PR TITLE
Hotfix: prevent undefined pattern code from crashing strudel on load

### DIFF
--- a/website/src/metadata_parser.js
+++ b/website/src/metadata_parser.js
@@ -1,6 +1,10 @@
 const ALLOW_MANY = ['by', 'url', 'genre', 'license'];
 
 export function getMetadata(raw_code) {
+  if (raw_code == null) {
+    console.error('saved pattern is empty or corrupted')
+    raw_code = '';
+  }
   const comment_regexp = /\/\*([\s\S]*?)\*\/|\/\/(.*)$/gm;
   const comments = [...raw_code.matchAll(comment_regexp)].map((c) => (c[1] || c[2] || '').trim());
   const tags = {};

--- a/website/src/metadata_parser.js
+++ b/website/src/metadata_parser.js
@@ -1,9 +1,10 @@
 const ALLOW_MANY = ['by', 'url', 'genre', 'license'];
+import { defaultCode } from './user_pattern_utils.mjs';
 
 export function getMetadata(raw_code) {
   if (raw_code == null) {
-    console.error('saved pattern is empty or corrupted')
-    raw_code = '';
+    console.error('could not extract metadata from missing pattern code');
+    raw_code = defaultCode;
   }
   const comment_regexp = /\/\*([\s\S]*?)\*\/|\/\/(.*)$/gm;
   const comments = [...raw_code.matchAll(comment_regexp)].map((c) => (c[1] || c[2] || '').trim());

--- a/website/src/repl/components/panel/PatternsTab.jsx
+++ b/website/src/repl/components/panel/PatternsTab.jsx
@@ -27,13 +27,9 @@ export function PatternLabel({ pattern } /* : { pattern: Tables<'code'> } */) {
     const date = new Date(pattern.created_at);
     if (!isNaN(date)) {
       title = date.toLocaleDateString();
+    } else {
+      title = 'unnamed';
     }
-  }
-  if (title == null) {
-    title = pattern.hash;
-  }
-  if (title == null) {
-    title = 'unnamed';
   }
 
   const author = Array.isArray(meta.by) ? meta.by.join(',') : 'Anonymous';

--- a/website/src/user_pattern_utils.mjs
+++ b/website/src/user_pattern_utils.mjs
@@ -111,7 +111,7 @@ export function useActivePattern() {
 
 export const setLatestCode = (code) => settingsMap.setKey('latestCode', code);
 
-const defaultCode = '';
+export const defaultCode = '';
 export const userPattern = {
   collection: patternFilterName.user,
   getAll() {


### PR DESCRIPTION
Im not sure how pattern code can be saved as undefined (maybe app crashed while saving?), but it happened to a user in the Discord. This logs an error to the console and prevents strudel from crashing.