### PR TITLE
Fix test error #1297

### DIFF
--- a/website/src/metadata_parser.js
+++ b/website/src/metadata_parser.js
@@ -1,10 +1,9 @@
 const ALLOW_MANY = ['by', 'url', 'genre', 'license'];
-import { defaultCode } from './user_pattern_utils.mjs';
 
 export function getMetadata(raw_code) {
   if (raw_code == null) {
     console.error('could not extract metadata from missing pattern code');
-    raw_code = defaultCode;
+    raw_code = '';
   }
   const comment_regexp = /\/\*([\s\S]*?)\*\/|\/\/(.*)$/gm;
   const comments = [...raw_code.matchAll(comment_regexp)].map((c) => (c[1] || c[2] || '').trim());


### PR DESCRIPTION
Still quite get it why  but it seems 

referencing `user_pattern_utils.mjs` from `medadata_parser.js` 

```
import { defaultCode } from './user_pattern_utils.mjs';
``` 

actualized the following circular dependency 

between 
`website/src/user_pattern_utils.mjs`
```jsx 
import { confirmDialog, parseJSON, supabase } from './repl/util.mjs';
```
and 
`website/src/repl/util.mjs`
```jsx
import { $featuredPatterns, loadDBPatterns } from '@src/user_pattern_utils.mjs';
```

and triggered test error on @strudel/tidal for want of a nail.




