### PR TITLE
feat: clip samples to duration when the buffer is longer than 1.5 seconds

### DIFF
--- a/packages/superdough/sampler.mjs
+++ b/packages/superdough/sampler.mjs
@@ -303,10 +303,9 @@ export async function onTriggerSample(t, value, onended, bank, resolveUrl) {
   const sbs = await getSampleBufferSource(value, bank, resolveUrl);
  const { bufferSource, sliceDuration, offset,bufferDuration } = sbs
 
-  // asny stuff above took too long?
+  // any stuff above took too long?
   if (ac.currentTime > t) {
     logger(`[sampler] still loading sound "${s}:${n}"`, 'highlight');
-    // console.warn('sample still loading:', s, n);
     return;
   }
   if (!bufferSource) {

--- a/packages/superdough/sampler.mjs
+++ b/packages/superdough/sampler.mjs
@@ -301,7 +301,7 @@ export async function onTriggerSample(t, value, onended, bank, resolveUrl) {
   let [attack, decay, sustain, release] = getADSRValues([value.attack, value.decay, value.sustain, value.release]);
 
   const sbs = await getSampleBufferSource(value, bank, resolveUrl);
- const { bufferSource, sliceDuration, offset,bufferDuration } = sbs
+  const { bufferSource, sliceDuration, offset, bufferDuration } = sbs;
 
   // any stuff above took too long?
   if (ac.currentTime > t) {
@@ -323,7 +323,7 @@ export async function onTriggerSample(t, value, onended, bank, resolveUrl) {
   const envGain = ac.createGain();
   const node = bufferSource.connect(envGain);
 
-  const clipDeltaSeconds = 1.5
+  const clipDeltaSeconds = 1.5;
 
   // if none of these controls is set, the duration of the sound will be set to the duration of the sample slice
   if (clip == null && loop == null && value.release == null && bufferDuration < clipDeltaSeconds) {

--- a/packages/superdough/sampler.mjs
+++ b/packages/superdough/sampler.mjs
@@ -300,7 +300,8 @@ export async function onTriggerSample(t, value, onended, bank, resolveUrl) {
   // destructure adsr here, because the default should be different for synths and samples
   let [attack, decay, sustain, release] = getADSRValues([value.attack, value.decay, value.sustain, value.release]);
 
-  const { bufferSource, sliceDuration, offset } = await getSampleBufferSource(value, bank, resolveUrl);
+  const sbs = await getSampleBufferSource(value, bank, resolveUrl);
+ const { bufferSource, sliceDuration, offset,bufferDuration } = sbs
 
   // asny stuff above took too long?
   if (ac.currentTime > t) {
@@ -317,13 +318,16 @@ export async function onTriggerSample(t, value, onended, bank, resolveUrl) {
   let vibratoOscillator = getVibratoOscillator(bufferSource.detune, value, t);
 
   const time = t + nudge;
+
   bufferSource.start(time, offset);
 
   const envGain = ac.createGain();
   const node = bufferSource.connect(envGain);
 
+  const clipDeltaSeconds = 1.5
+
   // if none of these controls is set, the duration of the sound will be set to the duration of the sample slice
-  if (clip == null && loop == null && value.release == null) {
+  if (clip == null && loop == null && value.release == null && bufferDuration < clipDeltaSeconds) {
     duration = sliceDuration;
   }
   let holdEnd = t + duration;


### PR DESCRIPTION
This is one of the biggest problems I see people running into when using long samples without clip() causes performance drops and crackles. Now percussion samples (usually shorter than 1.5 seconds) can keep their tales and longer sounds will be the appropriate duration.