### PR TITLE
enhancement: make error messages easier to read

### DIFF
--- a/website/src/repl/components/UserFacingErrorMessage.jsx
+++ b/website/src/repl/components/UserFacingErrorMessage.jsx
@@ -4,5 +4,9 @@ export default function UserFacingErrorMessage(Props) {
   if (error == null) {
     return;
   }
-  return <div className="text-background px-2 py-1 bg-foreground w-full ml-auto">Error: {error.message || 'Unknown Error :-/'}</div>;
+  return (
+    <div className="text-background px-2 py-1 bg-foreground w-full ml-auto">
+      Error: {error.message || 'Unknown Error :-/'}
+    </div>
+  );
 }

--- a/website/src/repl/components/UserFacingErrorMessage.jsx
+++ b/website/src/repl/components/UserFacingErrorMessage.jsx
@@ -4,5 +4,5 @@ export default function UserFacingErrorMessage(Props) {
   if (error == null) {
     return;
   }
-  return <div className="text-red-500 p-4 bg-lineHighlight animate-pulse">{error.message || 'Unknown Error :-/'}</div>;
+  return <div className="text-background px-2 py-1 bg-foreground w-full ml-auto">Error: {error.message || 'Unknown Error :-/'}</div>;
 }


### PR DESCRIPTION
Previously, the message would blink red, which made it hard to read the actual problem. This style tweak makes the error message more readable while still drawing attention
<img width="1410" alt="Screenshot 2025-03-24 at 1 27 41 AM" src="https://github.com/user-attachments/assets/d08e2296-c08c-4444-a8d4-d2643ef24958" />
