### PR TITLE
fix: replace empty spaces in registered sound keys

### DIFF
--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -17,8 +17,7 @@ import { loadBuffer } from './sampler.mjs';
 export const soundMap = map();
 
 export function registerSound(key, onTrigger, data = {}) {
-  key = key.toLowerCase().replace(/\s+/g, '_')
-  console.info(key, data)
+  key = key.toLowerCase().replace(/\s+/g, '_');
   soundMap.setKey(key, { onTrigger, data });
 }
 

--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -17,7 +17,9 @@ import { loadBuffer } from './sampler.mjs';
 export const soundMap = map();
 
 export function registerSound(key, onTrigger, data = {}) {
-  soundMap.setKey(key.toLowerCase(), { onTrigger, data });
+  key = key.toLowerCase().replace(/\s+/g, '_')
+  console.info(key, data)
+  soundMap.setKey(key, { onTrigger, data });
 }
 
 function aliasBankMap(aliasMap) {


### PR DESCRIPTION
`my cool   sound.wav` becomes `my_cool_sound` when registered in the sound panel, allowing you to pattern it properly