### PR TITLE
FIX: Set default gain to 1

### DIFF
--- a/packages/superdough/superdough.mjs
+++ b/packages/superdough/superdough.mjs
@@ -118,7 +118,7 @@ export const getAudioDevices = async () => {
 
 const defaultDefaultValues = {
   s: 'triangle',
-  gain: 0.8,
+  gain: 1,
   postgain: 1,
   density: '.03',
   ftype: '12db',


### PR DESCRIPTION
A default gain of 0.8 is not intuitive, because it is an invisible value. This change allows you to think of 1 as full volume, 0.8 as 80%, 0.5 as 50% etc.