### PR TITLE
Add Gamepad button mapping support

### DIFF
--- a/packages/gamepad/README.md
+++ b/packages/gamepad/README.md
@@ -14,7 +14,12 @@ npm i @strudel/gamepad --save
 import { gamepad } from '@strudel/gamepad';
 
 // Initialize gamepad (optional index parameter, defaults to 0)
-const pad = gamepad(0);
+const pad = gamepad(0); // Default mapping is XBOX {a: 0, b: 1, x: 2, y: 3}
+
+//const pad = gamepad(0, 'XBOX'); // XBOX button mapping {a: 0, b: 1, x: 2, y: 3}
+//const pad = gamepad(0, 'NES'); // Nintendo button mapping {a: 1, b: 0, x: 3, y: 2}
+//const pad = gamepad(0, {a: 0, b: 1, x: 2, y: 3}); // Custom mapping
+
 
 // Use gamepad inputs in patterns
 const pattern = sequence([
@@ -86,6 +91,7 @@ $: sound("hadoken").gain(pad.checkSequence(HADOKEN))
 ## Multiple Gamepads
 
 You can connect multiple gamepads by specifying the gamepad index:
+Make sure to press buttons on all connected gamepads before hitting play, so the browser can properly detect them.
 
 ```javascript
 const pad1 = gamepad(0);  // First gamepad

--- a/packages/gamepad/docs/gamepad.mdx
+++ b/packages/gamepad/docs/gamepad.mdx
@@ -113,17 +113,20 @@ samples({free_hadouken: 'https://cdn.freesound.org/previews/67/67674_111920-lq.m
 The gamepad module supports different button mapping configurations to accommodate various gamepad layouts:
 
 - **XBOX** (Default): Standard Xbox-style mapping where A=0, B=1, X=2, Y=3
-- **NES**: Nintendo-style mapping where B=0, A=1, Y=2, X=3 
+- **NES**: Nintendo-style mapping where B=0, A=1, Y=2, X=3
 - **Custom**: Define your own button mapping by passing an object with button assignments
 
 You can specify the mapping when initializing the gamepad:
 
-<MiniRepl client:idle tune={`
+<MiniRepl
+  client:idle
+  tune={`
 const pad1 = gamepad(0); // Default mapping is XBOX {a: 0, b: 1, x: 2, y: 3}
 const pad2 = gamepad(1, 'XBOX'); // XBOX button mapping {a: 0, b: 1, x: 2, y: 3}
 const pad3 = gamepad(2, 'NES'); // Nintendo button mapping {a: 1, b: 0, x: 3, y: 2}
 const pad4 = gamepad(3, {a: 0, b: 1, x: 2, y: 3}); // Custom mapping
-`} />
+`}
+/>
 
 ### Multiple Gamepads
 

--- a/packages/gamepad/docs/gamepad.mdx
+++ b/packages/gamepad/docs/gamepad.mdx
@@ -106,9 +106,29 @@ $: s("free_hadouken -").slow(2)
 samples({free_hadouken: 'https://cdn.freesound.org/previews/67/67674_111920-lq.mp3'})
 `} />
 
-## Multiple Gamepads
+### Button Sequences
+
+### Button Mappings
+
+The gamepad module supports different button mapping configurations to accommodate various gamepad layouts:
+
+- **XBOX** (Default): Standard Xbox-style mapping where A=0, B=1, X=2, Y=3
+- **NES**: Nintendo-style mapping where B=0, A=1, Y=2, X=3 
+- **Custom**: Define your own button mapping by passing an object with button assignments
+
+You can specify the mapping when initializing the gamepad:
+
+<MiniRepl client:idle tune={`
+const pad1 = gamepad(0); // Default mapping is XBOX {a: 0, b: 1, x: 2, y: 3}
+const pad2 = gamepad(1, 'XBOX'); // XBOX button mapping {a: 0, b: 1, x: 2, y: 3}
+const pad3 = gamepad(2, 'NES'); // Nintendo button mapping {a: 1, b: 0, x: 3, y: 2}
+const pad4 = gamepad(3, {a: 0, b: 1, x: 2, y: 3}); // Custom mapping
+`} />
+
+### Multiple Gamepads
 
 Strudel supports multiple gamepads. You can specify the gamepad index to connect to different devices.
+Make sure to press buttons on all connected gamepads before hitting play, so the browser can properly detect them.
 
 <MiniRepl
   client:idle

--- a/packages/gamepad/gamepad.mjs
+++ b/packages/gamepad/gamepad.mjs
@@ -5,24 +5,52 @@ import { signal } from '@strudel/core';
 // Button mapping for Logitech Dual Action (STANDARD GAMEPAD Vendor: 046d Product: c216)
 
 const buttonMapSettings = {
-  XBOX: { // XBOX mapping default
-    a: 0, b: 1, x: 2, y: 3,
-    lb: 4, rb: 5, lt: 6, rt: 7,
-    back: 8, start: 9,
-    u: 12, up: 12, d: 13, down: 13,
-    l: 14, left: 14, r: 15, right: 15
+  XBOX: {
+    // XBOX mapping default
+    a: 0,
+    b: 1,
+    x: 2,
+    y: 3,
+    lb: 4,
+    rb: 5,
+    lt: 6,
+    rt: 7,
+    back: 8,
+    start: 9,
+    u: 12,
+    up: 12,
+    d: 13,
+    down: 13,
+    l: 14,
+    left: 14,
+    r: 15,
+    right: 15,
   },
-  NES: { // Nintendo mapping
-    a: 1, b: 0, x: 3, y: 2,
-    lb: 4, rb: 5, lt: 6, rt: 7,
-    back: 8, start: 9,
-    u: 12, up: 12, d: 13, down: 13,
-    l: 14, left: 14, r: 15, right: 15
-  }
+  NES: {
+    // Nintendo mapping
+    a: 1,
+    b: 0,
+    x: 3,
+    y: 2,
+    lb: 4,
+    rb: 5,
+    lt: 6,
+    rt: 7,
+    back: 8,
+    start: 9,
+    u: 12,
+    up: 12,
+    d: 13,
+    down: 13,
+    l: 14,
+    left: 14,
+    r: 15,
+    right: 15,
+  },
 };
 
 class ButtonSequenceDetector {
-  constructor(timeWindow = 1000,mapping) {
+  constructor(timeWindow = 1000, mapping) {
     this.sequence = [];
     this.timeWindow = timeWindow;
     this.lastInputTime = 0;
@@ -42,7 +70,8 @@ class ButtonSequenceDetector {
       }
 
       // Store the button name instead of index
-      const buttonName = Object.keys(this.buttonMap).find((key) => this.buttonMap[key] === buttonIndex) || buttonIndex.toString();
+      const buttonName =
+        Object.keys(this.buttonMap).find((key) => this.buttonMap[key] === buttonIndex) || buttonIndex.toString();
 
       this.sequence.push({
         input: buttonName,
@@ -83,7 +112,7 @@ class ButtonSequenceDetector {
     return lastInputs.every((input, index) => {
       const target = sequence[index];
       // Check if either the input matches directly or they refer to the same button in the map
-      return (  
+      return (
         input === target ||
         this.buttonMap[input] === this.buttonMap[target] ||
         // Also check if the numerical index matches
@@ -96,7 +125,7 @@ class ButtonSequenceDetector {
 }
 
 class GamepadHandler {
-  constructor(index = 0,mapping) {
+  constructor(index = 0, mapping) {
     // Add index parameter
     this._gamepads = {};
     this._mapping = mapping;
@@ -146,15 +175,15 @@ class GamepadHandler {
 export const listGamepads = () => {
   const gamepads = navigator.getGamepads();
   const connectedGamepads = Array.from(gamepads)
-    .filter(gp => gp !== null)
-    .map(gp => ({
+    .filter((gp) => gp !== null)
+    .map((gp) => ({
       id: gp.id,
       index: gp.index,
       mapping: gp.mapping,
       buttons: gp.buttons.length,
       axes: gp.axes.length,
       connected: gp.connected,
-      timestamp: gp.timestamp
+      timestamp: gp.timestamp,
     }));
 
   logger('Connected Gamepads:', connectedGamepads);
@@ -165,21 +194,21 @@ export const listGamepads = () => {
 const gamepadStates = new Map();
 
 export const gamepad = (index = 0, mapping = 'XBOX') => {
-
   // Handle button mapping
-  let buttonMap = typeof mapping === 'string' 
-    ? buttonMapSettings[mapping.toUpperCase()]  
-    : typeof mapping === 'object' 
-      ? {...buttonMap, ...mapping}  
-      : buttonMapSettings.XBOX; 
+  let buttonMap =
+    typeof mapping === 'string'
+      ? buttonMapSettings[mapping.toUpperCase()]
+      : typeof mapping === 'object'
+        ? { ...buttonMap, ...mapping }
+        : buttonMapSettings.XBOX;
 
   if (!buttonMap) {
     logger(`Button mapping '${mapping}' not found`);
     return;
   }
 
-  const handler = new GamepadHandler(index,buttonMap);
-  const sequenceDetector = new ButtonSequenceDetector(2000,buttonMap);
+  const handler = new GamepadHandler(index, buttonMap);
+  const sequenceDetector = new ButtonSequenceDetector(2000, buttonMap);
 
   // Base signal that polls gamepad state and handles sequence detection
   const baseSignal = signal((t) => {

--- a/packages/gamepad/gamepad.mjs
+++ b/packages/gamepad/gamepad.mjs
@@ -1,6 +1,7 @@
 // @strudel/gamepad/index.mjs
 
 import { signal } from '@strudel/core';
+import { logger } from '@strudel/core';
 
 // Button mapping for Logitech Dual Action (STANDARD GAMEPAD Vendor: 046d Product: c216)
 

--- a/packages/gamepad/gamepad.mjs
+++ b/packages/gamepad/gamepad.mjs
@@ -209,12 +209,22 @@ export const gamepad = (index = 0, mapping = 'XBOX') => {
   }
 
   // Handle button mapping
-  let buttonMap =
-    typeof mapping === 'string'
-      ? buttonMapSettings[mapping.toUpperCase()]
-      : typeof mapping === 'object'
-        ? { ...buttonMap, ...mapping }
-        : buttonMapSettings.XBOX;
+  let buttonMap = buttonMapSettings.XBOX;
+
+  if (typeof mapping === 'string') {
+    buttonMap = buttonMapSettings[mapping.toUpperCase()];
+  } else if (typeof mapping === 'object') {
+    buttonMap = { ...buttonMapSettings.XBOX, ...mapping };
+    // Check that all mapping values are valid button indices
+    const maxButtons = requestedGamepad.buttons; // Standard gamepad has 16 buttons
+    for (const [key, value] of Object.entries(mapping)) {
+      if (typeof value !== 'number' || value < 0 || value >= maxButtons) {
+        throw new Error(
+          `[gamepad] invalid button mapping for '${key}': ${value}. Must be a number between 0 and ${maxButtons - 1}`,
+        );
+      }
+    }
+  }
 
   if (!buttonMap) {
     throw new Error(`[gamepad] button mapping '${mapping}' not found`);
@@ -296,7 +306,9 @@ export const gamepad = (index = 0, mapping = 'XBOX') => {
   const btnseq = btnSequence;
   const seq = btnSequence;
 
-  logger(`[gamepad] connected to gamepad ${index} (${requestedGamepad.id}) with ${mapping} mapping`);
+  logger(
+    `[gamepad] connected to gamepad ${index} (${requestedGamepad.id}) with ${typeof mapping === 'object' ? 'custom' : mapping} mapping`,
+  );
 
   // Return an object with all controls
   return {

--- a/packages/gamepad/gamepad.mjs
+++ b/packages/gamepad/gamepad.mjs
@@ -178,16 +178,18 @@ export const listGamepads = () => {
   const connectedGamepads = Array.from(gamepads)
     .filter((gp) => gp !== null)
     .map((gp) => ({
-      id: gp.id,
       index: gp.index,
+      id: gp.id,
       mapping: gp.mapping,
       buttons: gp.buttons.length,
       axes: gp.axes.length,
       connected: gp.connected,
       timestamp: gp.timestamp,
     }));
+  // Format the gamepads info into a readable string
+  const gamepadsInfo = connectedGamepads.map((gp) => `${gp.index}: ${gp.id}`).join('\n');
 
-  logger('Connected Gamepads:', connectedGamepads);
+  logger(`[gamepad] available gamepads:\n${gamepadsInfo}`);
   return connectedGamepads;
 };
 
@@ -195,6 +197,17 @@ export const listGamepads = () => {
 const gamepadStates = new Map();
 
 export const gamepad = (index = 0, mapping = 'XBOX') => {
+  // list connected gamepads
+  const connectedGamepads = listGamepads();
+
+  // Check if the requested gamepad index exists
+  const requestedGamepad = connectedGamepads.find((gp) => gp.index === index);
+  if (!requestedGamepad) {
+    throw new Error(
+      `[gamepad] gamepad at index ${index} not found. available gamepads: ${connectedGamepads.map((gp) => gp.index).join(', ')}`,
+    );
+  }
+
   // Handle button mapping
   let buttonMap =
     typeof mapping === 'string'
@@ -204,8 +217,7 @@ export const gamepad = (index = 0, mapping = 'XBOX') => {
         : buttonMapSettings.XBOX;
 
   if (!buttonMap) {
-    logger(`Button mapping '${mapping}' not found`);
-    return;
+    throw new Error(`[gamepad] button mapping '${mapping}' not found`);
   }
 
   const handler = new GamepadHandler(index, buttonMap);
@@ -283,6 +295,8 @@ export const gamepad = (index = 0, mapping = 'XBOX') => {
   const btnSeq = btnSequence;
   const btnseq = btnSequence;
   const seq = btnSequence;
+
+  logger(`[gamepad] connected to gamepad ${index} (${requestedGamepad.id}) with ${mapping} mapping`);
 
   // Return an object with all controls
   return {


### PR DESCRIPTION
- Added support for different gamepad button mappings (XBOX, NES, custom).
- Refactored global `buttonMap` to instance variable to support multiple gamepad mappings
 
### Usage 
```jsx

const pad1 = gamepad(0); // Default mapping is XBOX {a: 0, b: 1, x: 2, y: 3}
const pad2 = gamepad(1, 'XBOX'); // XBOX button mapping {a: 0, b: 1, x: 2, y: 3}
const pad3 = gamepad(2, 'NES'); // Nintendo button mapping {a: 1, b: 0, x: 3, y: 2}
const pad4 = gamepad(3, {a: 0, b: 1, x: 2, y: 3}); // Custom mapping

```