### PR TITLE
Add browser cache explanation in samples.mdx

### DIFF
--- a/website/src/pages/learn/samples.mdx
+++ b/website/src/pages/learn/samples.mdx
@@ -167,9 +167,11 @@ Please note that browsers will often cache `strudel.json` on first load, and kee
 version even if the orginal has been updated. If this bites you (for example while developing a new
 sample pack), you can force the browser to download a new copy by i.e. changing capitalization of one
 character in the URL, or adding a URL attribute, such as:
+
 ```javascript
-samples('https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/strudel.json?version=2')
+samples('https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/strudel.json?version=2');
 ```
+
 that gets ignored by GitHub (but changes the URL, forcing the browser to reload every time we increase
 the version number).
 

--- a/website/src/pages/learn/samples.mdx
+++ b/website/src/pages/learn/samples.mdx
@@ -163,6 +163,12 @@ The last section could be written as:
 }
 ```
 
+Please note that browsers will often cache `strudel.json` on first load, and keep using the cached
+version even if the orginal has been updated. If this bites you (for example while developing a new
+sample pack), you can force the browser to download a new copy by i.e. changing capitalization of one
+character in the URL, or by removing it from cache (deleting cache in browser Privacy settings, or from
+the dev console if you're technically minded, or by using a cache deleting extension).
+
 ## Github Shortcut
 
 Because loading samples from github is common, there is a shortcut:

--- a/website/src/pages/learn/samples.mdx
+++ b/website/src/pages/learn/samples.mdx
@@ -166,8 +166,15 @@ The last section could be written as:
 Please note that browsers will often cache `strudel.json` on first load, and keep using the cached
 version even if the orginal has been updated. If this bites you (for example while developing a new
 sample pack), you can force the browser to download a new copy by i.e. changing capitalization of one
-character in the URL, or by removing it from cache (deleting cache in browser Privacy settings, or from
-the dev console if you're technically minded, or by using a cache deleting extension).
+character in the URL, or adding a URL attribute, such as:
+```javascript
+samples('https://raw.githubusercontent.com/tidalcycles/Dirt-Samples/master/strudel.json?version=2')
+```
+that gets ignored by GitHub (but changes the URL, forcing the browser to reload every time we increase
+the version number).
+
+It is also possible, of course, to just remove it from cache (deleting cache in browser Privacy settings,
+or from the dev console if you're technically minded, or by using a cache deleting extension).
 
 ## Github Shortcut
 


### PR DESCRIPTION
Several users (including me) have been bitten by this, so it's perhaps worth mentioning in the docs that the strudel.json file gets cached by the browser and doesn't reload properly unless forced.